### PR TITLE
Add possibility to force timelib_long to be 32-bit on 64-bit build

### DIFF
--- a/timelib_structs.h
+++ b/timelib_structs.h
@@ -125,7 +125,7 @@ typedef unsigned __int64  uint64_t;
 #include <strings.h>
 #endif
 
-#if defined(__x86_64__) || defined(__LP64__) || defined(_LP64) || defined(_WIN64)
+#if (defined(__x86_64__) || defined(__LP64__) || defined(_LP64) || defined(_WIN64)) && !defined(TIMELIB_FORCE_LONG32)
 typedef int64_t timelib_long;
 typedef uint64_t timelib_ulong;
 # define TIMELIB_LONG_MAX INT64_MAX


### PR DESCRIPTION
This particularly helps to retain compatibility with PHP5 Windows builbs, which always use 32-bit longs even in 64-bit builds.
