### PR TITLE
Insert LDFLAGS after source file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,37 +20,37 @@ timelib.a: parse_iso_intervals.o parse_date.o unixtime2tm.o tm2unixtime.o dow.o 
 	ar -rc timelib.a parse_iso_intervals.o parse_date.o unixtime2tm.o tm2unixtime.o dow.o parse_tz.o parse_zoneinfo.o timelib.o astro.o interval.o
 
 tests/tester-diff: timelib.a tests/tester-diff.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/tester-diff tests/tester-diff.c timelib.a
+	gcc $(CFLAGS) -o tests/tester-diff tests/tester-diff.c timelib.a $(LDFLAGS)
 
 tests/tester-parse-string: timelib.a tests/tester-parse-string.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/tester-parse-string tests/tester-parse-string.c timelib.a
+	gcc $(CFLAGS) -o tests/tester-parse-string tests/tester-parse-string.c timelib.a $(LDFLAGS)
 
 tests/tester-parse-interval: timelib.a tests/tester-parse-interval.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/tester-parse-interval tests/tester-parse-interval.c timelib.a
+	gcc $(CFLAGS) -o tests/tester-parse-interval tests/tester-parse-interval.c timelib.a $(LDFLAGS)
 
 tests/tester-parse-string-by-format: timelib.a tests/tester-parse-string-by-format.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/tester-parse-string-by-format tests/tester-parse-string-by-format.c timelib.a
+	gcc $(CFLAGS) -o tests/tester-parse-string-by-format tests/tester-parse-string-by-format.c timelib.a $(LDFLAGS)
 
 tests/tester-create-ts: timelib.a tests/tester-create-ts.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/tester-create-ts tests/tester-create-ts.c timelib.a
+	gcc $(CFLAGS) -o tests/tester-create-ts tests/tester-create-ts.c timelib.a $(LDFLAGS)
 
 tests/tester-parse-tz: timelib.a tests/test-tz-parser.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/tester-parse-tz tests/test-tz-parser.c timelib.a
+	gcc $(CFLAGS) -o tests/tester-parse-tz tests/test-tz-parser.c timelib.a $(LDFLAGS)
 
 tests/tester-render-ts: timelib.a tests/tester-render-ts.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/tester-render-ts tests/tester-render-ts.c timelib.a
+	gcc $(CFLAGS) -o tests/tester-render-ts tests/tester-render-ts.c timelib.a $(LDFLAGS)
 
 tests/tester-render-ts-zoneinfo: timelib.a tests/tester-render-ts-zoneinfo.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/tester-render-ts-zoneinfo tests/tester-render-ts-zoneinfo.c timelib.a
+	gcc $(CFLAGS) -o tests/tester-render-ts-zoneinfo tests/tester-render-ts-zoneinfo.c timelib.a $(LDFLAGS)
 
 tests/tester-iso-week: timelib.a tests/tester-iso-week.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/tester-iso-week tests/tester-iso-week.c timelib.a
+	gcc $(CFLAGS) -o tests/tester-iso-week tests/tester-iso-week.c timelib.a $(LDFLAGS)
 
 tests/test-abbr-to-id: timelib.a tests/test-abbr-to-id.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/test-abbr-to-id tests/test-abbr-to-id.c timelib.a
+	gcc $(CFLAGS) -o tests/test-abbr-to-id tests/test-abbr-to-id.c timelib.a $(LDFLAGS)
 
 tests/test-astro: timelib.a tests/test-astro.c
-	gcc $(CFLAGS) $(LDFLAGS) -o tests/test-astro tests/test-astro.c timelib.a -lm
+	gcc $(CFLAGS) -o tests/test-astro tests/test-astro.c timelib.a $(LDFLAGS)
 
 timezonemap.h: gettzmapping.php
 	echo Generating timezone mapping file.


### PR DESCRIPTION
`-lm` should be specified _after_ the source file on the command line. This is explained [here](http://www.network-theory.co.uk/docs/gccintro/gccintro_18.html).

Fixes #4.