### PR TITLE
Inefficient algorithm for converting ts to GMT time in timelib_unixtime2gmt

### DIFF
--- a/unixtime2tm.c
+++ b/unixtime2tm.c
@@ -32,80 +32,81 @@ static int month_tab[12] =      { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 3
 /* Converts a Unix timestamp value into broken down time, in GMT */
 void timelib_unixtime2gmt(timelib_time* tm, timelib_sll ts)
 {
-	timelib_sll days, remainder, tmp_days;
+	timelib_sll days = 0, remainder = 0;
 	timelib_sll cur_year = 1970;
 	timelib_sll i;
 	timelib_sll hours, minutes, seconds;
 	int *months;
 
-	days = ts / SECS_PER_DAY;
-	remainder = ts - (days * SECS_PER_DAY);
+	remainder = ts;
+	days = remainder / SECS_PER_DAY;
+	remainder %= SECS_PER_DAY;
+
 	if (ts < 0 && remainder == 0) {
 		days++;
 		remainder -= SECS_PER_DAY;
 	}
-	TIMELIB_DEBUG(printf("days=%lld, rem=%lld\n", days, remainder););
+
+	/* Speed up the year calculation a lot if the given timestamp is greater
+	   than 12,622,780,800 seconds (DAYS_PER_LYEAR_PERIOD * SECS_PER_DAY)
+	   or lower than -12,622,780,800 seconds */
+	if (days >= DAYS_PER_LYEAR_PERIOD || days <= -DAYS_PER_LYEAR_PERIOD) {
+		cur_year += days / DAYS_PER_LYEAR_PERIOD * YEARS_PER_LYEAR_PERIOD;
+		days %= DAYS_PER_LYEAR_PERIOD;
+	}
+
+	TIMELIB_DEBUG(printf("days=%lld, year=%lld\n", days, cur_year););
 
 	if (ts >= 0) {
-		tmp_days = days + 1;
+		days++;
 
-		if (tmp_days > DAYS_PER_LYEAR_PERIOD || tmp_days <= -DAYS_PER_LYEAR_PERIOD) {
-			cur_year += YEARS_PER_LYEAR_PERIOD * (tmp_days / DAYS_PER_LYEAR_PERIOD);
-			tmp_days -= DAYS_PER_LYEAR_PERIOD * (tmp_days / DAYS_PER_LYEAR_PERIOD);
-		}
-
-		while (tmp_days >= DAYS_PER_LYEAR) {
+		while (days >= DAYS_PER_LYEAR) {
 			cur_year++;
 			if (timelib_is_leap(cur_year)) {
-				tmp_days -= DAYS_PER_LYEAR;
+				days -= DAYS_PER_LYEAR;
 			} else {
-				tmp_days -= DAYS_PER_YEAR;
+				days -= DAYS_PER_YEAR;
 			}
 		}
-	} else {
-		tmp_days = days;
+	}
+	else {
+		remainder += SECS_PER_DAY;
 
 		/* Guess why this might be for, it has to do with a pope ;-). It's also
-		 * only valid for Great Brittain and it's colonies. It needs fixing for
+		 * only valid for Great Britain and it's colonies. It needs fixing for
 		 * other locales. *sigh*, why is this crap so complex! */
 		/*
 		if (ts <= TIMELIB_LL_CONST(-6857352000)) {
-			tmp_days -= 11;
+			days -= 11;
 		}
 		*/
 
-		while (tmp_days <= 0) {
-			if (tmp_days < -1460970) {
-				cur_year -= 4000;
-				TIMELIB_DEBUG(printf("tmp_days=%lld, year=%lld\n", tmp_days, cur_year););
-				tmp_days += 1460970;
+		while (days <= 0) {
+			cur_year--;
+			if (timelib_is_leap(cur_year)) {
+				days += DAYS_PER_LYEAR;
 			} else {
-				cur_year--;
-				TIMELIB_DEBUG(printf("tmp_days=%lld, year=%lld\n", tmp_days, cur_year););
-				if (timelib_is_leap(cur_year)) {
-					tmp_days += DAYS_PER_LYEAR;
-				} else {
-					tmp_days += DAYS_PER_YEAR;
-				}
+				days += DAYS_PER_YEAR;
 			}
 		}
-		remainder += SECS_PER_DAY;
 	}
-	TIMELIB_DEBUG(printf("tmp_days=%lld, year=%lld\n", tmp_days, cur_year););
+
+	TIMELIB_DEBUG(printf("days=%lld, year=%lld\n", days, cur_year););
 
 	months = timelib_is_leap(cur_year) ? month_tab_leap : month_tab;
 	if (timelib_is_leap(cur_year) && cur_year < 1970) {
-		tmp_days--;
+		days--;
 	}
+
 	i = 11;
 	while (i > 0) {
 		TIMELIB_DEBUG(printf("month=%lld (%d)\n", i, months[i]););
-		if (tmp_days > months[i]) {
+		if (days > months[i]) {
 			break;
 		}
 		i--;
 	}
-	TIMELIB_DEBUG(printf("A: ts=%lld, year=%lld, month=%lld, day=%lld,", ts, cur_year, i + 1, tmp_days - months[i]););
+	TIMELIB_DEBUG(printf("A: ts=%lld, year=%lld, month=%lld, day=%lld,", ts, cur_year, i + 1, days - months[i]););
 
 	/* That was the date, now we do the tiiiime */
 	hours = remainder / 3600;
@@ -115,7 +116,7 @@ void timelib_unixtime2gmt(timelib_time* tm, timelib_sll ts)
 
 	tm->y = cur_year;
 	tm->m = i + 1;
-	tm->d = tmp_days - months[i];
+	tm->d = days - months[i];
 	tm->h = hours;
 	tm->i = minutes;
 	tm->s = seconds;


### PR DESCRIPTION
getTransitions is slow with large negative or positive values. With the default values PHP_INT_MIN and PHP_INT_MAX the function takes a very long time.

https://github.com/php/php-src/pull/2693
https://bugs.php.net/bug.php?id=75088
