### PR TITLE
fix build with old gcc

### DIFF
--- a/timelib_private.h
+++ b/timelib_private.h
@@ -115,7 +115,7 @@
 		m = NULL;   \
 	}
 
-typedef struct ttinfo
+struct ttinfo
 {
 	int32_t      offset;
 	int          isdst;
@@ -123,13 +123,13 @@ typedef struct ttinfo
 
 	unsigned int isstdcnt;
 	unsigned int isgmtcnt;
-} ttinfo;
+};
 
-typedef struct tlinfo
+struct tlinfo
 {
 	int32_t  trans;
 	int32_t  offset;
-} tlinfo;
+};
 
 
 #ifndef LONG_MAX


### PR DESCRIPTION
At least, that fix is needed for gcc 4.4 on RHEL-6
Tested with 4.4 and 7.1

Without (building PHP-7.2.0RC1)
```
In file included from /builddir/build/BUILD/php-7.2.0RC1/ext/date/php_date.c:33:
/builddir/build/BUILD/php-7.2.0RC1/ext/date/lib/timelib_private.h:126: error: redefinition of typedef 'ttinfo'
/builddir/build/BUILD/php-7.2.0RC1/ext/date/lib/timelib.h:134: note: previous declaration of 'ttinfo' was here
/builddir/build/BUILD/php-7.2.0RC1/ext/date/lib/timelib_private.h:132: error: redefinition of typedef 'tlinfo'
/builddir/build/BUILD/php-7.2.0RC1/ext/date/lib/timelib.h:135: note: previous declaration of 'tlinfo' was here
```