### PR TITLE
Get rid of warnings about dropping const from timelib_tzd pointer

### DIFF
--- a/parse_tz.c
+++ b/parse_tz.c
@@ -424,7 +424,7 @@ const timelib_tzdb *timelib_builtin_db(void)
 	return &timezonedb_builtin;
 }
 
-const timelib_tzdb_index_entry *timelib_timezone_identifiers_list(timelib_tzdb *tzdb, int *count)
+const timelib_tzdb_index_entry *timelib_timezone_identifiers_list(const timelib_tzdb *tzdb, int *count)
 {
 	*count = tzdb->index_size;
 	return tzdb->index;

--- a/timelib.h
+++ b/timelib.h
@@ -661,7 +661,7 @@ const timelib_tzdb *timelib_builtin_db(void);
  * Each entry contains the time zone ID ('id' field), and the position within the time zone
  * information ('pos' field). The pos field should not be used.
  */
-const timelib_tzdb_index_entry *timelib_timezone_identifiers_list(timelib_tzdb *tzdb, int *count);
+const timelib_tzdb_index_entry *timelib_timezone_identifiers_list(const timelib_tzdb *tzdb, int *count);
 
 /* From parse_zoneinfo.c */
 


### PR DESCRIPTION
Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>