### PR TITLE
Remove unused Git ident attributes

### DIFF
--- a/parse_date.re
+++ b/parse_date.re
@@ -22,8 +22,6 @@
  * THE SOFTWARE.
  */
 
-/* $Id$ */
-
 #include "timelib.h"
 #include "timelib_private.h"
 

--- a/parse_iso_intervals.re
+++ b/parse_iso_intervals.re
@@ -22,8 +22,6 @@
  * THE SOFTWARE.
  */
 
-/* $Id$ */
-
 #include "timelib.h"
 #include "timelib_private.h"
 

--- a/timelib.m4
+++ b/timelib.m4
@@ -1,7 +1,4 @@
 dnl
-dnl $Id$
-dnl
-dnl
 dnl TL_DEF_HAVE(what [, why])
 dnl
 dnl Generates 'AC_DEFINE(HAVE_WHAT, 1, [WHY])'


### PR DESCRIPTION
Hello, this patch removes unused Git ident attributes which were used in times of SVN with keywords substitution, where $Id$ was replaced with latest repository revision and author name. In Git this functionality is different and needs to be defined for each file manually in the .gitattributes file.

Thanks for checking this out or considering merging it.