### PR TITLE
Remove HAVE_LIMITS_H

### DIFF
--- a/timelib_private.h
+++ b/timelib_private.h
@@ -68,10 +68,7 @@
 #endif
 
 #include <stdio.h>
-
-#if HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #define TIMELIB_SECOND   1
 #define TIMELIB_MINUTE   2


### PR DESCRIPTION
The `<limits.h>` header file is part of the standard C89 headers [1] and
on current systems there is no need to do a manual check anymore if
header is present.

Build systems (such as Autoconf) could check for the presence of this
header file and defined the `HAVE_LIMITS_H` symbol.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.4
[2] http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4