### PR TITLE
Remove HAVE_STRING_H

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ FLAGS=-O0 -ggdb3 \
 	-Wall -Werror -Wextra -fsanitize=undefined -fsanitize=address \
 	-Wmaybe-uninitialized -Wmissing-field-initializers -Wshadow -Wno-unused-parameter \
 	-pedantic -Wno-implicit-fallthrough \
-	-DHAVE_STDINT_H -DHAVE_STRING_H -DHAVE_GETTIMEOFDAY -DHAVE_UNISTD_H -DHAVE_DIRENT_H -I.# -DDEBUG_PARSER
+	-DHAVE_STDINT_H -DHAVE_GETTIMEOFDAY -DHAVE_UNISTD_H -DHAVE_DIRENT_H -I.# -DDEBUG_PARSER
 
 CFLAGS=-Wdeclaration-after-statement ${FLAGS}
 

--- a/timelib.m4
+++ b/timelib.m4
@@ -70,7 +70,6 @@ sys/time.h \
 sys/types.h \
 stdint.h \
 dirent.h \
-string.h \
 strings.h \
 unistd.h \
 io.h

--- a/timelib_private.h
+++ b/timelib_private.h
@@ -39,9 +39,7 @@
 # endif
 #endif
 
-#ifdef HAVE_STRING_H
-# include <string.h>
-#endif
+#include <string.h>
 
 #ifdef HAVE_STRINGS_H
 # include <strings.h>


### PR DESCRIPTION
The `<string.h>` header file is part of the standard C89 headers [1]
and on current systems a manual check if header is present is not needed
anymore [2].

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4