### PR TITLE
Remove HAVE_STRINGS_H and <strings.h>

### DIFF
--- a/timelib.m4
+++ b/timelib.m4
@@ -70,7 +70,6 @@ sys/time.h \
 sys/types.h \
 stdint.h \
 dirent.h \
-strings.h \
 unistd.h \
 io.h
 ])

--- a/timelib_private.h
+++ b/timelib_private.h
@@ -41,10 +41,6 @@
 
 #include <string.h>
 
-#ifdef HAVE_STRINGS_H
-# include <strings.h>
-#endif
-
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
This patch removes not needed `HAVE_STRINGS_H` symbol as was defined by
Autoconf in configure.ac and also `<strings.h>` header inclusion.

Current source code doesn't need the POSIX `<strings.h>` [1]
header file included as none of the functions defined by it are used:
* ffs
* strcasecmp
* strcasecmp_l
* strncasecmp
* strncasecmp_l
* bcmp (LEGACY)
* bcopy (LEGACY)
* bzero (LEGACY)
* *index (LEGACY)
* *rindex (LEGACY)

The `<string.h>` file (part of C89 standard and above) [2] is
sufficient for it.

[1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/strings.h.html
[2] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2