### PR TITLE
Fix use of uninitialized variable

### DIFF
--- a/parse_tz.c
+++ b/parse_tz.c
@@ -604,8 +604,8 @@ static ttinfo* fetch_timezone_offset(timelib_tzinfo *tz, timelib_sll ts, timelib
 	/* If there is no transition time, we pick the first one, if that doesn't
 	 * exist we return NULL */
 	if (!tz->bit64.timecnt || !tz->trans) {
-		*transition_time = 0;
 		if (tz->bit64.typecnt == 1) {
+			*transition_time = INT64_MIN;
 			return &(tz->type[0]);
 		}
 		return NULL;
@@ -616,6 +616,7 @@ static ttinfo* fetch_timezone_offset(timelib_tzinfo *tz, timelib_sll ts, timelib
 	 * one in case there are only DST entries. Not sure which smartass came up
 	 * with this idea in the first though :) */
 	if (ts < tz->trans[0]) {
+		*transition_time = INT64_MIN;
 		return &(tz->type[0]);
 	}
 

--- a/tests/c/issues.cpp
+++ b/tests/c/issues.cpp
@@ -340,3 +340,39 @@ TEST(issues, issue0053_test3)
 	timelib_time_dtor(t);
 	timelib_tzinfo_dtor(tzi);
 }
+
+/* Test for no transitions */
+TEST(issues, issue0065_test1)
+{
+	int                  dummy_error;
+	timelib_tzinfo      *tzi;
+	timelib_time_offset *offset;
+
+	tzi = timelib_parse_tzfile((char*) "Etc/Gmt+5", timelib_builtin_db(), &dummy_error);
+	offset = timelib_get_time_zone_info(-1822500432, tzi);
+
+	LONGS_EQUAL(INT64_MIN, offset->transition_time);
+
+	timelib_time_offset_dtor(offset);
+	timelib_tzinfo_dtor(tzi);
+}
+
+/* Test for offset from time before first transition */
+TEST(issues, issue0065_test2)
+{
+	int                  dummy_error;
+	timelib_tzinfo      *tzi;
+	timelib_time_offset *offset;
+
+	tzi = timelib_parse_tzfile((char*) "Europe/London", timelib_builtin_db(), &dummy_error);
+
+	offset = timelib_get_time_zone_info(-3852662326, tzi);
+	LONGS_EQUAL(INT64_MIN, offset->transition_time);
+	timelib_time_offset_dtor(offset);
+
+	offset = timelib_get_time_zone_info(-3852662325, tzi);
+	LONGS_EQUAL(-3852662325, offset->transition_time);
+	timelib_time_offset_dtor(offset);
+
+	timelib_tzinfo_dtor(tzi);
+}


### PR DESCRIPTION
The fetch_timezone_offset() function does not always set a value in 'transition_time' before returning. Initialize beforehand to prevent use of uninitialized value.