### PR TITLE
Handle week, day edge cases in timelib_date_from_isodate

### DIFF
--- a/tests/date_from_isodate.c
+++ b/tests/date_from_isodate.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include "timelib.h"
 
-#define TEST_COUNT 33
+#define TEST_COUNT 37
 
 timelib_sll tests[TEST_COUNT][2][3] = {
 	{ { 2014, 52, 1 }, { 2014, 12, 22 } },
@@ -70,6 +70,10 @@ timelib_sll tests[TEST_COUNT][2][3] = {
 	{ { 2043, 53, 5 }, { 2044,  1,  1 } },
 	{ { 2043, 53, 6 }, { 2044,  1,  2 } },
 	{ { 2043, 53, 7 }, { 2044,  1,  3 } },
+	{ { 2019,  0, 1 }, { 2018, 12, 24 } },
+	{ { 2019, -1, 1 }, { 2018, 12, 17 } },
+	{ { 2019, 62, 1 }, { 2020,  3,  2 } },
+	{ { 2019,110, 1 }, { 2021,  2,  1 } },
 };
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Hi, Derick, from MongoDB! How have you been?

A customer found a bug in how we process some $dateFromParts commands ([SERVER-40383](https://jira.mongodb.org/browse/SERVER-40383)), and the fix involves changes to timelib. These changes might be useful to PHP as well, so I'm filing this pull request. We'd also be interested in any feedback you have if you get a chance to look over the change.

The goal is to update timelib_daynr_from_week so that it always returns in-range month and day values and avoids reading the "table" array for months after 12. This should make timelib_daynr_from_week usable for more applications, but callers may want to restrict very high magnitude values for "iw" or "id" inputs, because they will cause the function to loop for a prohibitively long time.