### PR TITLE
alternate way to check for big-endian on Debian mips64 and sparc64

### DIFF
--- a/parse_tz.c
+++ b/parse_tz.c
@@ -39,6 +39,12 @@
 # endif
 #endif
 
+#if (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN))
+# if __BYTE_ORDER == __BIG_ENDIAN
+#  define WORDS_BIGENDIAN
+# endif
+#endif
+
 #if defined(__s390__)
 # if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #  define WORDS_BIGENDIAN


### PR DESCRIPTION
This patch fixes a crash on big-endian Debain machines like mips64 and sparc64 that we observed when parsing the timezonedb in @hebcal.