### PR TITLE
Handle abbreviated timezones separately

### DIFF
--- a/parse_date.re
+++ b/parse_date.re
@@ -727,21 +727,25 @@ static timelib_long timelib_lookup_abbr(char **ptr, int *dst, char **tz_abbr, in
 		value -= tp->type * 3600;
 		*found = 1;
 	} else {
+		char *cpy = timelib_calloc(1, end - begin + 1);
 		char *pos = NULL;
-		if((pos = strrchr(word, '-')) == NULL){
-			*found = 0;
-		} else {
+
+		memcpy(cpy, word, end - begin);
+
+		while((pos = strrchr(cpy, '-')) != NULL){
 			*pos = '\0';
-			if((tp = abbr_search(word,-1,0))){
+			if((tp = abbr_search(cpy, -1, 0))){
 				value = tp->gmtoffset;
 				*dst = tp->type;
 				value -= tp->type * 3600;
 				*found = 1;
-				*ptr -= pos - word + 2;
-			} else {
-				*pos = '-';
+				*ptr = begin + (pos - cpy);
+				*tz_abbr = cpy;
+				timelib_free(word);
+				return value;
 			}
 		}
+		timelib_free(cpy);
 	}
 
 	*tz_abbr = word;

--- a/parse_date.re
+++ b/parse_date.re
@@ -727,7 +727,21 @@ static timelib_long timelib_lookup_abbr(char **ptr, int *dst, char **tz_abbr, in
 		value -= tp->type * 3600;
 		*found = 1;
 	} else {
-		*found = 0;
+		char *pos = NULL;
+		if((pos = strrchr(word, '-')) == NULL){
+			*found = 0;
+		} else {
+			*pos = '\0';
+			if((tp = abbr_search(word,-1,0))){
+				value = tp->gmtoffset;
+				*dst = tp->type;
+				value -= tp->type * 3600;
+				*found = 1;
+				*ptr -= pos - word + 2;
+			} else {
+				*pos = '-';
+			}
+		}
 	}
 
 	*tz_abbr = word;

--- a/parse_date.re
+++ b/parse_date.re
@@ -716,8 +716,11 @@ static timelib_long timelib_lookup_abbr(char **ptr, int *dst, char **tz_abbr, in
 	timelib_long  value = 0;
 	const timelib_tz_lookup_table *tp;
 
+	int has_dash = 0;
 	while (**ptr != '\0' && **ptr != ')' && **ptr != ' ') {
-		++*ptr;
+		if(*((*ptr)++) == '-'){
+			has_dash = 1;
+		}
 	}
 	end = *ptr;
 	word = timelib_calloc(1, end - begin + 1);
@@ -727,7 +730,7 @@ static timelib_long timelib_lookup_abbr(char **ptr, int *dst, char **tz_abbr, in
 		value = TIMELIB_TP_VALUE(tp);
 		*dst = tp->type;
 		*found = 1;
-	} else {
+	} else if(has_dash) {
 		char *cpy = timelib_calloc(1, end - begin + 1);
 		char *pos = NULL;
 
@@ -747,6 +750,8 @@ static timelib_long timelib_lookup_abbr(char **ptr, int *dst, char **tz_abbr, in
 			}
 		}
 		timelib_free(cpy);
+	} else {
+		*found = 0;
 	}
 
 	*tz_abbr = word;

--- a/parse_date.re
+++ b/parse_date.re
@@ -750,6 +750,7 @@ static timelib_long timelib_lookup_abbr(char **ptr, int *dst, char **tz_abbr, in
 			}
 		}
 		timelib_free(cpy);
+		*found = 0;
 	} else {
 		*found = 0;
 	}

--- a/parse_date.re
+++ b/parse_date.re
@@ -707,6 +707,8 @@ static const timelib_tz_lookup_table* abbr_search(const char *word, timelib_long
 	return NULL;
 }
 
+#define TIMELIB_TP_VALUE(tp) tp->gmtoffset - (tp->type * 3600)
+
 static timelib_long timelib_lookup_abbr(char **ptr, int *dst, char **tz_abbr, int *found)
 {
 	char *word;
@@ -722,9 +724,8 @@ static timelib_long timelib_lookup_abbr(char **ptr, int *dst, char **tz_abbr, in
 	memcpy(word, begin, end - begin);
 
 	if ((tp = abbr_search(word, -1, 0))) {
-		value = tp->gmtoffset;
+		value = TIMELIB_TP_VALUE(tp);
 		*dst = tp->type;
-		value -= tp->type * 3600;
 		*found = 1;
 	} else {
 		char *cpy = timelib_calloc(1, end - begin + 1);
@@ -735,9 +736,9 @@ static timelib_long timelib_lookup_abbr(char **ptr, int *dst, char **tz_abbr, in
 		while((pos = strrchr(cpy, '-')) != NULL){
 			*pos = '\0';
 			if((tp = abbr_search(cpy, -1, 0))){
-				value = tp->gmtoffset;
+				value = TIMELIB_TP_VALUE(tp);
 				*dst = tp->type;
-				value -= tp->type * 3600;
+
 				*found = 1;
 				*ptr = begin + (pos - cpy);
 				*tz_abbr = cpy;

--- a/tests/files/tz-identifier.parseformat
+++ b/tests/files/tz-identifier.parseformat
@@ -2,4 +2,4 @@ TS: 0 | -99999--99999--99999 01:00:03 0.123450 Europe/Amsterdam | H:i:s.u e | 01
 TS: 0 | -99999--99999--99999 01:00:03 0.123450 America/Indiana/Knox | H:i:s.u e | 01:00:03.12345 America/Indiana/Knox
 TS: 0 | 2005-07-14 22:30:41 America/Los_Angeles | Y-m-d H:i:s e | 2005-07-14 22:30:41 America/Los_Angeles
 TS: 0 | 2005-07-14 22:30:41 America/Los_Angeles | Y-m-d?H:i:s?e | 2005-07-14	22:30:41	America/Los_Angeles
-TS: 0 | 2020-02-25 10:21:25 CET 03600  0Y   0M   0D /   0H   0M   0S / 2.1 | D-M-d-H.i.s-T-Y | Tue-Feb-25-10.21.25-CET-2020
+TS: 0 | 2020-02-25 10:21:25 CET  0Y   0M   0D /   0H   0M   0S / 2.1 | D-M-d-H.i.s-T-Y | Tue-Feb-25-10.21.25-CET-2020

--- a/tests/files/tz-identifier.parseformat
+++ b/tests/files/tz-identifier.parseformat
@@ -2,3 +2,4 @@ TS: 0 | -99999--99999--99999 01:00:03 0.123450 Europe/Amsterdam | H:i:s.u e | 01
 TS: 0 | -99999--99999--99999 01:00:03 0.123450 America/Indiana/Knox | H:i:s.u e | 01:00:03.12345 America/Indiana/Knox
 TS: 0 | 2005-07-14 22:30:41 America/Los_Angeles | Y-m-d H:i:s e | 2005-07-14 22:30:41 America/Los_Angeles
 TS: 0 | 2005-07-14 22:30:41 America/Los_Angeles | Y-m-d?H:i:s?e | 2005-07-14	22:30:41	America/Los_Angeles
+TS: 0 | 2020-02-25 10:21:25 CET 03600  0Y   0M   0D /   0H   0M   0S / 2.1 | D-M-d-H.i.s-T-Y | Tue-Feb-25-10.21.25-CET-2020

--- a/timelib.h
+++ b/timelib.h
@@ -380,6 +380,7 @@ typedef enum _timelib_format_specifier_code {
 	TIMELIB_FORMAT_TEXTUAL_MONTH_3_LETTER,
 	TIMELIB_FORMAT_TEXTUAL_MONTH_FULL,
 	TIMELIB_FORMAT_TIMEZONE_OFFSET,
+	TIMELIB_FORMAT_TIMEZONE_ABBREV,
 	TIMELIB_FORMAT_TIMEZONE_OFFSET_MINUTES,
 	TIMELIB_FORMAT_WEEK_OF_YEAR_ISO,
 	TIMELIB_FORMAT_WEEK_OF_YEAR,
@@ -552,7 +553,7 @@ const timelib_tz_lookup_table *timelib_timezone_abbreviations_list(void);
 /**
  * DEPRECATED, but still used by PHP.
  */
-timelib_long timelib_parse_zone(char **ptr, int *dst, timelib_time *t, int *tz_not_found, const timelib_tzdb *tzdb, timelib_tz_get_wrapper tz_wrapper);
+timelib_long timelib_parse_zone(char **ptr, int *dst, timelib_time *t, int is_abbrev, int *tz_not_found, const timelib_tzdb *tzdb, timelib_tz_get_wrapper tz_wrapper);
 
 /* From parse_iso_intervals.re */
 


### PR DESCRIPTION
The bug happens when parsing a time string that contains a timezone not immediately followed by a space
Already discovered here: https://stackoverflow.com/a/8988859