### PR TITLE
Read timezone files in binary mode

### DIFF
--- a/parse_zoneinfo.c
+++ b/parse_zoneinfo.c
@@ -123,7 +123,8 @@ static char *read_tzfile(const char *directory, const char *timezone, size_t *le
 		return NULL;
 	}
 
-	fd = open(fname, O_RDONLY);
+	/* O_BINARY is required to properly read the file on windows */
+	fd = open(fname, O_BINARY);
 	free(fname);
 
 	if (fd == -1) {


### PR DESCRIPTION
It looks like this is required on windows platforms. In one particular example, it looks like America/Sao_Paulo is failing to read the whole file. In a debugger I was able to confirm it reads fewer than 400 bytes out of the expected 1444, returning null on line 144.

According to the docs here, it looks like CTRL-Z is treated as EOF on windows in text mode (the default): https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=vs-2019

I confirmed that America/Sao_Paolo does have that character in it, around the expected location given what I saw as the value for `read_bytes` in the debugger. 

It's also worth noting that 'read' is subject to return fewer bytes in general if there is a signal or interrupt. So a better pattern here may be a while loop, but I am not experienced with anything like that so I've left as is. 

I'm also not sure how to write a test for this case, but I have confirmed this solves it for me. We got a bug report over on https://jira.mongodb.org/browse/SERVER-44273