### PR TITLE
Fix quadratic slowdown under asan

### DIFF
--- a/parse_date.re
+++ b/parse_date.re
@@ -331,44 +331,55 @@ uchar *fill(Scanner *s, uchar *cursor){
 }
 #endif
 
+static timelib_error_message *alloc_error_message(timelib_error_message **messages, int *count)
+{
+	/* Realloc in power of two increments */
+	int is_pow2 = (*count & (*count - 1)) == 0;
+	if (is_pow2) {
+		size_t alloc_size = *count ? *count * 2 : 1;
+		*messages = timelib_realloc(*messages, alloc_size * sizeof(timelib_error_message));
+	}
+	return *messages + (*count)++;
+}
+
 static void add_warning(Scanner *s, int error_code, char *error)
 {
-	s->errors->warning_count++;
-	s->errors->warning_messages = timelib_realloc(s->errors->warning_messages, s->errors->warning_count * sizeof(timelib_error_message));
-	s->errors->warning_messages[s->errors->warning_count - 1].error_code = error_code;
-	s->errors->warning_messages[s->errors->warning_count - 1].position = s->tok ? s->tok - s->str : 0;
-	s->errors->warning_messages[s->errors->warning_count - 1].character = s->tok ? *s->tok : 0;
-	s->errors->warning_messages[s->errors->warning_count - 1].message = timelib_strdup(error);
+	timelib_error_message *message =
+		alloc_error_message(&s->errors->warning_messages, &s->errors->warning_count);
+	message->error_code = error_code;
+	message->position = s->tok ? s->tok - s->str : 0;
+	message->character = s->tok ? *s->tok : 0;
+	message->message = timelib_strdup(error);
 }
 
 static void add_error(Scanner *s, int error_code, char *error)
 {
-	s->errors->error_count++;
-	s->errors->error_messages = timelib_realloc(s->errors->error_messages, s->errors->error_count * sizeof(timelib_error_message));
-	s->errors->error_messages[s->errors->error_count - 1].error_code = error_code;
-	s->errors->error_messages[s->errors->error_count - 1].position = s->tok ? s->tok - s->str : 0;
-	s->errors->error_messages[s->errors->error_count - 1].character = s->tok ? *s->tok : 0;
-	s->errors->error_messages[s->errors->error_count - 1].message = timelib_strdup(error);
+	timelib_error_message *message =
+		alloc_error_message(&s->errors->error_messages, &s->errors->error_count);
+	message->error_code = error_code;
+	message->position = s->tok ? s->tok - s->str : 0;
+	message->character = s->tok ? *s->tok : 0;
+	message->message = timelib_strdup(error);
 }
 
 static void add_pbf_warning(Scanner *s, int error_code, char *error, const char *sptr, const char *cptr)
 {
-	s->errors->warning_count++;
-	s->errors->warning_messages = timelib_realloc(s->errors->warning_messages, s->errors->warning_count * sizeof(timelib_error_message));
-	s->errors->warning_messages[s->errors->warning_count - 1].error_code = error_code;
-	s->errors->warning_messages[s->errors->warning_count - 1].position = cptr - sptr;
-	s->errors->warning_messages[s->errors->warning_count - 1].character = *cptr;
-	s->errors->warning_messages[s->errors->warning_count - 1].message = timelib_strdup(error);
+	timelib_error_message *message =
+		alloc_error_message(&s->errors->warning_messages, &s->errors->warning_count);
+	message->error_code = error_code;
+	message->position = cptr - sptr;
+	message->character = *cptr;
+	message->message = timelib_strdup(error);
 }
 
 static void add_pbf_error(Scanner *s, int error_code, char *error, const char *sptr, const char *cptr)
 {
-	s->errors->error_count++;
-	s->errors->error_messages = timelib_realloc(s->errors->error_messages, s->errors->error_count * sizeof(timelib_error_message));
-	s->errors->error_messages[s->errors->error_count - 1].error_code = error_code;
-	s->errors->error_messages[s->errors->error_count - 1].position = cptr - sptr;
-	s->errors->error_messages[s->errors->error_count - 1].character = *cptr;
-	s->errors->error_messages[s->errors->error_count - 1].message = timelib_strdup(error);
+	timelib_error_message *message =
+		alloc_error_message(&s->errors->error_messages, &s->errors->error_count);
+	message->error_code = error_code;
+	message->position = cptr - sptr;
+	message->character = *cptr;
+	message->message = timelib_strdup(error);
 }
 
 static timelib_sll timelib_meridian(const char **ptr, timelib_sll h)


### PR DESCRIPTION
When parsing strings with a large number of errors, say `new DateTime(str_repeat("x", 1024 * 256))` and running under asan, we currently get quadratic performance degradation. Fix this by reallocating the error/warnings buffers with the typical power of two scheme.

Currently fuzzing under asan is running into this timeout a lot.