### PR TITLE
Avoid uninitialized `transition_time` in `parse_tz.c`

### DIFF
--- a/parse_tz.c
+++ b/parse_tz.c
@@ -885,7 +885,7 @@ timelib_time_offset *timelib_get_time_zone_info(timelib_sll ts, timelib_tzinfo *
 	int32_t offset = 0, leap_secs = 0;
 	char *abbr;
 	timelib_time_offset *tmp = timelib_time_offset_ctor();
-	timelib_sll                transition_time;
+	timelib_sll transition_time = 0;
 
 	if ((to = timelib_fetch_timezone_offset(tz, ts, &transition_time))) {
 		offset = to->offset;


### PR DESCRIPTION
Our team saw this on `gcc-10` when compiling with `-O3`. It doesn't show up with `-O2`, probably due to less aggressive inlining not making it visible to the compiler.

```bash
src/third_party/timelib-2018.01/parse_tz.c: In function 'timelib_get_time_zone_info':
src/third_party/timelib-2018.01/parse_tz.c:677:24: error: 'transition_time' may be used uninitialized in this function [-Werror=maybe-uninitialized]
```

It seems like a valid warning since `transition_time` won't be initialized if this return path is taken https://github.com/derickr/timelib/blob/175cf44d2ee480551f7ec66521465b2e895d00a1/parse_tz.c#L817.

This PR fixes the issue by Initializing to 0 at https://github.com/mdashti/timelib/blob/5e4e10fa919a29343a67a9a6d392850d872d7759/parse_tz.c#L888.