### PR TITLE
RFC: don't skip /usr/share/zoneinfo/Etc

### DIFF
--- a/parse_zoneinfo.c
+++ b/parse_zoneinfo.c
@@ -63,7 +63,6 @@ static int index_filter(const struct dirent *ent)
 		&& strcmp(ent->d_name, "posix") != 0
 		&& strcmp(ent->d_name, "posixrules") != 0
 		&& strcmp(ent->d_name, "right") != 0
-		&& strcmp(ent->d_name, "Etc") != 0
 		&& strcmp(ent->d_name, "localtime") != 0
 		&& strstr(ent->d_name, ".list") == NULL
 		&& strstr(ent->d_name, ".tab") == NULL;


### PR DESCRIPTION
This directory does contain tzdata, for example, `Etc/UTC`, which is also included in the embedded tzdata. 

It's a bit surprising that Etc/UTC is usable with the embedded tzdata, but not with the system zoneinfo, even though it's included there.

For example:

```
$ ./tester-render-ts 1631827447 Etc/UTC
TYPE: 3 TS: 1631827447 | 2021-09-16 21:24:07 UTC Etc/UTC
$ ./tester-render-ts-zoneinfo 1631827447 Etc/UTC
Timezone identifier "Etc/UTC" does not exist
$ cat /usr/share/zoneinfo/Etc/UTC
TZif2UTCTZif2�UTC
UTC0
```

This also affects `tests/enumerate-timezones`

Given skipping this is intentional, I'm guessing there's something I'm missing?