### PR TITLE
Avoid filtering out `Etc` timezone files when reading system tzfiles

### DIFF
--- a/parse_zoneinfo.c
+++ b/parse_zoneinfo.c
@@ -63,7 +63,6 @@ static int index_filter(const struct dirent *ent)
 		&& strcmp(ent->d_name, "posix") != 0
 		&& strcmp(ent->d_name, "posixrules") != 0
 		&& strcmp(ent->d_name, "right") != 0
-		&& strcmp(ent->d_name, "Etc") != 0
 		&& strcmp(ent->d_name, "localtime") != 0
 		&& strstr(ent->d_name, ".list") == NULL
 		&& strstr(ent->d_name, ".tab") == NULL;


### PR DESCRIPTION
In our usage of `timelib` at MongoDB, we noticed that `Etc` timezones are missing when the timezones are read from system files: https://jira.mongodb.org/browse/SERVER-59701

I could not find any reason as to why it's being filtered here. Then, went ahead and tested whether including them becomes problematic or not. As far as I see, there is no problem with including `Etc` timezones.

This PR avoids filtering out `Etc` timezone files when reading system tzfiles.