### PR TITLE
Fix typo "can not" to "cannot" in error messages

### DIFF
--- a/docs/show-tzinfo.c
+++ b/docs/show-tzinfo.c
@@ -33,13 +33,13 @@ int main(int argc, char *argv[])
 		timelib_tzdb *db = timelib_zoneinfo(argv[2]);
 
 		if (!db) {
-			fprintf(stderr, "Can not read timezone database in '%s'.\n", argv[2]);
+			fprintf(stderr, "Cannot read timezone database in '%s'.\n", argv[2]);
 			return 2;
 		}
 
 		tz = timelib_parse_tzfile(argv[1], db, &dummy_error);
 		if (!tz) {
-			fprintf(stderr, "Can not read timezone identifier '%s' from database in '%s'.\n", argv[1], argv[2]);
+			fprintf(stderr, "Cannot read timezone identifier '%s' from database in '%s'.\n", argv[1], argv[2]);
 
 			timelib_zoneinfo_dtor(db);
 			return 3;
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
 	} else {
 		tz = timelib_parse_tzfile(argv[1], timelib_builtin_db(), &dummy_error);
 		if (!tz) {
-			fprintf(stderr, "Can not read timezone identifier '%s' from built in database.\n", argv[1]);
+			fprintf(stderr, "Cannot read timezone identifier '%s' from built in database.\n", argv[1]);
 			return 4;
 		}
 	}

--- a/parse_date.re
+++ b/parse_date.re
@@ -2243,7 +2243,7 @@ timelib_time *timelib_parse_from_format_with_map(const char *format, const char 
 					break;
 				}
 				if (s->time->h > 12) {
-					add_pbf_error(s, TIMELIB_ERR_HOUR_LARGER_THAN_12, "Hour can not be higher than 12", string, begin);
+					add_pbf_error(s, TIMELIB_ERR_HOUR_LARGER_THAN_12, "Hour cannot be higher than 12", string, begin);
 					break;
 				}
 

--- a/timelib.c
+++ b/timelib.c
@@ -37,7 +37,7 @@
 
 const char *timelib_error_messages[10] = {
 	"No error",
-	"Can not allocate buffer for parsing",
+	"Cannot allocate buffer for parsing",
 	"Corrupt tzfile: The transitions in the file don't always increase",
 	"Corrupt tzfile: The expected 64-bit preamble is missing",
 	"Corrupt tzfile: No abbreviation could be found for a transition",


### PR DESCRIPTION
These two phrases have different meanings. The opposite of "can" is "cannot".