### PR TITLE
Fix negative us in unix timestamp syntax

### DIFF
--- a/parse_date.re
+++ b/parse_date.re
@@ -1145,6 +1145,7 @@ weekdayof        = (reltextnumber|reltexttext) space (dayfull|dayabbr) space 'of
 	{
 		timelib_ull i, us;
 		const char *ptr_before;
+		bool is_negative;
 
 		TIMELIB_INIT;
 		TIMELIB_HAVE_RELATIVE();
@@ -1152,11 +1153,14 @@ weekdayof        = (reltextnumber|reltexttext) space (dayfull|dayabbr) space 'of
 		TIMELIB_UNHAVE_TIME();
 		TIMELIB_HAVE_TZ();
 
+		is_negative = *(ptr + 1) == '-';
+
 		i = timelib_get_signed_nr(s, &ptr, 24);
 
 		ptr_before = ptr;
 		us = timelib_get_signed_nr(s, &ptr, 6);
 		us = us * pow(10, 7 - (ptr - ptr_before));
+		if (is_negative) us *= -1;
 
 		s->time->y = 1970;
 		s->time->m = 1;

--- a/tests/c/parse_date.cpp
+++ b/tests/c/parse_date.cpp
@@ -4898,6 +4898,19 @@ TEST(parse_date, timestamp_09)
 	LONGS_EQUAL(     3,     t->relative.us);
 }
 
+TEST(parse_date, timestamp_10)
+{
+	test_parse("@-0.4");
+	LONGS_EQUAL(1970, t->y);
+	LONGS_EQUAL( 1, t->m);
+	LONGS_EQUAL( 1, t->d);
+	LONGS_EQUAL( 0, t->h);
+	LONGS_EQUAL( 0, t->i);
+	LONGS_EQUAL( 0, t->s);
+	LONGS_EQUAL( 0, t->relative.s);
+	LONGS_EQUAL(-400000, t->relative.us);
+}
+
 
 TEST(parse_date, timetiny12_00)
 {

--- a/tests/c/timezones_same.cpp
+++ b/tests/c/timezones_same.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "timelib.h"
+#include <cstring>
 
 TEST_GROUP(timezone_same)
 {


### PR DESCRIPTION
https://github.com/php/php-src/issues/7758

Let me know if there's a better way to check for the negative symbol. I'm not super familiar with re2c.

Also, `tests/c/timezones_same.cpp` didn't compile for me because `strlen` wasn't defined.