### PR TITLE
Fix timelib_sub_wall() wrt. subseconds

### DIFF
--- a/interval.c
+++ b/interval.c
@@ -308,6 +308,7 @@ timelib_time *timelib_sub_wall(timelib_time *old_time, timelib_rel_time *interva
 		memcpy(&t->relative, interval, sizeof(timelib_rel_time));
 
 		timelib_update_ts(t, NULL);
+		timelib_update_from_sse(t);
 	} else {
 		if (interval->invert) {
 			bias = -1;
@@ -331,7 +332,6 @@ timelib_time *timelib_sub_wall(timelib_time *old_time, timelib_rel_time *interva
 		timelib_do_normalize(t);
 	}
 
-	timelib_update_from_sse(t);
 	if (t->zone_type == TIMELIB_ZONETYPE_ID) {
 		timelib_set_timezone(t, t->tz_info);
 	}

--- a/tests/c/interval.cpp
+++ b/tests/c/interval.cpp
@@ -91,7 +91,7 @@ TEST(timelib_interval, php80998_2b)
 TEST(timelib_interval, php80998_1a_sub)
 {
 	test_sub_wall("2021-04-05 11:00:00", "PT2H59M59S", 999999L, INVERT);
-	CHECKRES(2021,  4,  5, 14,  0,  0, 999999, 1617631200);
+	CHECKRES(2021,  4,  5, 13, 59, 59, 999999, 1617631200);
 }
 
 TEST(timelib_interval, php80998_1b_sub)
@@ -103,7 +103,7 @@ TEST(timelib_interval, php80998_1b_sub)
 TEST(timelib_interval, php80998_2a_sub)
 {
 	test_sub_wall("2021-04-05 11:00:00", "PT2H59M59S", 999999L, 0);
-	CHECKRES(2021,  4,  5,  8,  0,  1, 1, 1617609601);
+	CHECKRES(2021,  4,  5,  8,  0,  0, 1, 1617609601);
 }
 
 TEST(timelib_interval, php80998_2b_sub)


### PR DESCRIPTION
We must not call `timelib_update_from_sse()` after having manually
adjusted the µs, since that overwrites this change.