### PR TITLE
Added a new API, timelib_get_time_zone_offset_info, who returns the

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,4 +11,4 @@ support.
 Build Requirements
 ------------------
 
-On Debian: ``apt install libcpputest-dev``
+On Debian: ``apt install libcpputest-dev re2c``

--- a/interval.c
+++ b/interval.c
@@ -90,8 +90,9 @@ static void sort_old_to_new(timelib_time **one, timelib_time **two, timelib_rel_
 static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time *two)
 {
 	timelib_rel_time *rt;
-	timelib_sll dst_corr = 0, dst_h_corr = 0, dst_m_corr = 0;
-	timelib_time_offset *trans = NULL;
+	timelib_sll       dst_corr = 0, dst_h_corr = 0, dst_m_corr = 0;
+	int32_t           trans_offset;
+	timelib_sll       trans_transition_time;
 
 	rt = timelib_rel_time_ctor();
 	rt->invert = 0;
@@ -117,16 +118,12 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 	if (one->dst == 1 && two->dst == 0) {
 		/* First for two "Type 3" times */
 		if (one->zone_type == TIMELIB_ZONETYPE_ID && two->zone_type == TIMELIB_ZONETYPE_ID) {
-			trans = timelib_get_time_zone_info(two->sse, two->tz_info);
-			if (trans) {
-				if (one->sse < trans->transition_time && one->sse >= trans->transition_time + dst_corr) {
-					timelib_sll flipped = SECS_PER_HOUR + (rt->i * 60) + (rt->s);
-					rt->h = flipped / SECS_PER_HOUR;
-					rt->i = (flipped - rt->h * SECS_PER_HOUR) / 60;
-					rt->s = flipped % 60;
-				}
-				timelib_time_offset_dtor(trans);
-				trans = NULL;
+			timelib_get_time_zone_offset_info(two->sse, two->tz_info, &trans_offset, &trans_transition_time, NULL);
+			if (one->sse < trans_transition_time && one->sse >= trans_transition_time + dst_corr) {
+				timelib_sll flipped = SECS_PER_HOUR + (rt->i * 60) + (rt->s);
+				rt->h = flipped / SECS_PER_HOUR;
+				rt->i = (flipped - rt->h * SECS_PER_HOUR) / 60;
+				rt->s = flipped % 60;
 			}
 		} else if (rt->h == 0 && (rt->i < 0 || rt->s < 0)) {
 			/* Then for all the others */
@@ -145,12 +142,11 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 	if (one->zone_type == TIMELIB_ZONETYPE_ID && two->zone_type == TIMELIB_ZONETYPE_ID && strcmp(one->tz_info->name, two->tz_info->name) == 0) {
 		if (one->dst == 1 && two->dst == 0) { /* Fall Back */
 			if (two->tz_info) {
-				trans = timelib_get_time_zone_info(two->sse, two->tz_info);
+				timelib_get_time_zone_offset_info(two->sse, two->tz_info, &trans_offset, &trans_transition_time, NULL);
 
 				if (
-					trans &&
-					two->sse >= trans->transition_time &&
-					((two->sse - one->sse + dst_corr) % SECS_PER_DAY) > (two->sse - trans->transition_time)
+					two->sse >= trans_transition_time &&
+					((two->sse - one->sse + dst_corr) % SECS_PER_DAY) > (two->sse - trans_transition_time)
 				) {
 					rt->h -= dst_h_corr;
 					rt->i -= dst_m_corr;
@@ -158,13 +154,12 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 			}
 		} else if (one->dst == 0 && two->dst == 1) { /* Spring Forward */
 			if (two->tz_info) {
-				trans = timelib_get_time_zone_info(two->sse, two->tz_info);
+				timelib_get_time_zone_offset_info(two->sse, two->tz_info, &trans_offset, &trans_transition_time, NULL);
 
 				if (
-					trans &&
-					!((one->sse + SECS_PER_DAY > trans->transition_time) && (one->sse + SECS_PER_DAY <= (trans->transition_time + dst_corr))) &&
-					two->sse >= trans->transition_time &&
-					((two->sse - one->sse + dst_corr) % SECS_PER_DAY) > (two->sse - trans->transition_time)
+					!((one->sse + SECS_PER_DAY > trans_transition_time) && (one->sse + SECS_PER_DAY <= (trans_transition_time + dst_corr))) &&
+					two->sse >= trans_transition_time &&
+					((two->sse - one->sse + dst_corr) % SECS_PER_DAY) > (two->sse - trans_transition_time)
 				) {
 					rt->h -= dst_h_corr;
 					rt->i -= dst_m_corr;
@@ -172,10 +167,10 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 			}
 		} else if (two->sse - one->sse >= SECS_PER_DAY) {
 			/* Check whether we're in the period to the next transition time */
-			trans = timelib_get_time_zone_info(two->sse - two->z, two->tz_info);
-			dst_corr = one->z - trans->offset;
+			timelib_get_time_zone_offset_info(two->sse - two->z, two->tz_info, &trans_offset, &trans_transition_time, NULL);
+			dst_corr = one->z - trans_offset;
 
-			if (two->sse >= trans->transition_time - dst_corr && two->sse < trans->transition_time) {
+			if (two->sse >= trans_transition_time - dst_corr && two->sse < trans_transition_time) {
 				rt->d--;
 				rt->h = 24;
 			}
@@ -187,10 +182,6 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 		swap_if_negative(rt);
 
 		timelib_do_rel_normalize(rt->invert ? one : two, rt);
-	}
-
-	if (trans) {
-		timelib_time_offset_dtor(trans);
 	}
 
 	return rt;

--- a/parse_tz.c
+++ b/parse_tz.c
@@ -878,6 +878,34 @@ int timelib_timestamp_is_in_dst(timelib_sll ts, timelib_tzinfo *tz)
 	return -1;
 }
 
+void timelib_get_time_zone_offset_info(timelib_sll ts, timelib_tzinfo *tz, int32_t* offset, timelib_sll* transition_time, unsigned int* is_dst)
+{
+	ttinfo *to;
+	timelib_sll tmp_transition_time;
+
+	if ((to = timelib_fetch_timezone_offset(tz, ts, &tmp_transition_time))) {
+		if (offset) {
+			*offset = to->offset;
+		}
+		if (is_dst) {
+			*is_dst = to->isdst;
+		}
+		if (transition_time) {
+			*transition_time = tmp_transition_time;
+		}
+	} else {
+		if (offset) {
+			*offset = 0;
+		}
+		if (is_dst) {
+			*is_dst = 0;
+		}
+		if (transition_time) {
+			*transition_time = 0;
+		}
+	}
+}
+
 timelib_time_offset *timelib_get_time_zone_info(timelib_sll ts, timelib_tzinfo *tz)
 {
 	ttinfo *to;
@@ -912,19 +940,16 @@ timelib_time_offset *timelib_get_time_zone_info(timelib_sll ts, timelib_tzinfo *
 
 timelib_sll timelib_get_current_offset(timelib_time *t)
 {
-	timelib_time_offset *gmt_offset;
-	timelib_sll retval;
-
 	switch (t->zone_type) {
 		case TIMELIB_ZONETYPE_ABBR:
 		case TIMELIB_ZONETYPE_OFFSET:
 			return t->z + (t->dst * 3600);
 
-		case TIMELIB_ZONETYPE_ID:
-			gmt_offset = timelib_get_time_zone_info(t->sse, t->tz_info);
-			retval = gmt_offset->offset;
-			timelib_time_offset_dtor(gmt_offset);
-			return retval;
+		case TIMELIB_ZONETYPE_ID: {
+			int32_t      offset;
+			timelib_get_time_zone_offset_info(t->sse, t->tz_info, &offset, NULL, NULL);
+			return offset;
+		}
 
 		default:
 			return 0;

--- a/timelib.h
+++ b/timelib.h
@@ -794,6 +794,17 @@ int timelib_timestamp_is_in_dst(timelib_sll ts, timelib_tzinfo *tz);
 timelib_time_offset *timelib_get_time_zone_info(timelib_sll ts, timelib_tzinfo *tz);
 
 /**
+ * Returns offset information with time zone 'tz' for the time stamp 'ts'.
+ *
+ * The returned information contains: the offset in seconds East of UTC (in
+ * the output parameter 'offset'), whether DST is active (in the output
+ * parameter 'is_dst'), and the transition time that got to this state (in
+ * the output parameter 'transition_time'); if NULL is passed, the value is
+ * not retrieved
+ */
+void timelib_get_time_zone_offset_info(timelib_sll ts, timelib_tzinfo *tz, int32_t* offset, timelib_sll* transition_time, unsigned int* is_dst);
+
+/**
  * Returns the UTC offset currently applicable for the information stored in 't'.
  *
  * The value returned is the UTC offset in seconds East.

--- a/unixtime2tm.c
+++ b/unixtime2tm.c
@@ -97,11 +97,10 @@ void timelib_update_from_sse(timelib_time *tm)
 		}
 
 		case TIMELIB_ZONETYPE_ID: {
-			timelib_time_offset *gmt_offset;
+			int32_t  offset;
 
-			gmt_offset = timelib_get_time_zone_info(tm->sse, tm->tz_info);
-			timelib_unixtime2gmt(tm, tm->sse + gmt_offset->offset);
-			timelib_time_offset_dtor(gmt_offset);
+			timelib_get_time_zone_offset_info(tm->sse, tm->tz_info, &offset, NULL, NULL);
+			timelib_unixtime2gmt(tm, tm->sse + offset);
 
 			goto cleanup;
 		}


### PR DESCRIPTION
same offset, transition_time and is_dst information as the
timelib_get_time_zone_info API, but without wrapping them in a
heap-allocated structure that also includes a copy of the string
representing the timezone name. Reducing the number of allocations
improves the performance of the code.