### PR TITLE
Added a new API, timelib_get_time_zone_offset_info, who returns the

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ C_TESTS=tests/c/timelib_get_current_offset_test.o tests/c/timelib_decimal_hour.o
 	tests/c/parse_tz.o tests/c/render.o tests/c/create_ts_from_string.o \
 	tests/c/parse_date.o tests/c/php-rfc.o tests/c/diff.o tests/c/interval.o \
 	tests/c/timezones_same.o tests/c/diff_days.o \
-	tests/c/timelib_hmsf_to_decimal_hour.o tests/c/dow.o
+	tests/c/timelib_hmsf_to_decimal_hour.o tests/c/dow.o \
+	tests/c/timelib_get_offset_info_test.o
 
 TEST_BINARIES=${MANUAL_TESTS} ${AUTO_TESTS}
 

--- a/parse_tz.c
+++ b/parse_tz.c
@@ -910,6 +910,30 @@ timelib_time_offset *timelib_get_time_zone_info(timelib_sll ts, timelib_tzinfo *
 	return tmp;
 }
 
+int timelib_get_time_zone_offset_info(timelib_sll ts, timelib_tzinfo *tz, int32_t* offset, timelib_sll* transition_time, unsigned int* is_dst)
+{
+	ttinfo *to;
+	timelib_sll tmp_transition_time;
+
+	if (tz == NULL) {
+		return 0;
+	}
+
+	if ((to = timelib_fetch_timezone_offset(tz, ts, &tmp_transition_time))) {
+		if (offset) {
+			*offset = to->offset;
+		}
+		if (is_dst) {
+			*is_dst = to->isdst;
+		}
+		if (transition_time) {
+			*transition_time = tmp_transition_time;
+		}
+		return 1;
+	}
+	return 0;
+}
+
 timelib_sll timelib_get_current_offset(timelib_time *t)
 {
 	timelib_time_offset *gmt_offset;

--- a/tests/c/timelib_get_offset_info_test.cpp
+++ b/tests/c/timelib_get_offset_info_test.cpp
@@ -1,0 +1,77 @@
+#include "CppUTest/TestHarness.h"
+#include "timelib.h"
+
+TEST_GROUP(get_offset_info)
+{
+};
+
+TEST(get_offset_info, UTCPlusOffset)
+{
+	int32_t offset;
+	timelib_time* t = timelib_time_ctor();
+	timelib_set_timezone_from_offset(t, 5 * 3600);
+
+	timelib_unixtime2local(t, 1483280063);
+	CHECK_FALSE(timelib_get_time_zone_offset_info(t->sse, t->tz_info, &offset, NULL, NULL));
+
+	timelib_time_dtor(t);
+}
+
+TEST(get_offset_info, AbbreviatedTimeZone)
+{
+	int32_t offset;
+	timelib_abbr_info ai = { -5 * 3600, (char*) "EST", 0 };
+	timelib_time* t = timelib_time_ctor();
+	timelib_set_timezone_from_abbr(t, ai);
+
+	timelib_unixtime2local(t, 1483280063);
+	CHECK_FALSE(timelib_get_time_zone_offset_info(t->sse, t->tz_info, &offset, NULL, NULL));
+
+	timelib_time_dtor(t);
+}
+
+TEST(get_offset_info, London)
+{
+	int code;
+	int32_t offset;
+	timelib_sll transition;
+	unsigned int is_dst;
+	timelib_tzinfo* tzi = timelib_parse_tzfile((char*) "Europe/London", timelib_builtin_db(), &code);
+	timelib_time* t = timelib_time_ctor();
+	timelib_set_timezone(t, tzi);
+
+	timelib_unixtime2local(t, 1483280063); // 1483280063 = 2017-01-01
+	CHECK_TRUE(timelib_get_time_zone_offset_info(t->sse, t->tz_info, &offset, &transition, &is_dst));
+	LONGS_EQUAL(0, offset);
+	CHECK_FALSE(is_dst);
+	LONGS_EQUAL(1477789200, transition); // 1477789200 = 2016-10-30
+
+	timelib_unixtime2local(t, 1501074654); // 1501074654 = 2017-07-26
+	CHECK_TRUE(timelib_get_time_zone_offset_info(t->sse, t->tz_info, &offset, &transition, &is_dst));
+	LONGS_EQUAL(3600, offset);
+	CHECK_TRUE(is_dst);
+	LONGS_EQUAL(1490490000, transition); // 1490490000 = 2017-03-26
+
+	timelib_tzinfo_dtor(tzi);
+	timelib_time_dtor(t);
+}
+
+TEST(get_offset_info, Amsterdam)
+{
+	int code;
+	int32_t offset;
+	timelib_tzinfo* tzi = timelib_parse_tzfile((char*) "Europe/Amsterdam", timelib_builtin_db(), &code);
+	timelib_time* t = timelib_time_ctor();
+	timelib_set_timezone(t, tzi);
+
+	timelib_unixtime2local(t, 1483280063);
+	CHECK_TRUE(timelib_get_time_zone_offset_info(t->sse, t->tz_info, &offset, NULL, NULL));
+	LONGS_EQUAL(3600, offset);
+
+	timelib_unixtime2local(t, 1501074654);
+	CHECK_TRUE(timelib_get_time_zone_offset_info(t->sse, t->tz_info, &offset, NULL, NULL));
+	LONGS_EQUAL(7200, offset);
+
+	timelib_tzinfo_dtor(tzi);
+	timelib_time_dtor(t);
+}

--- a/timelib.h
+++ b/timelib.h
@@ -794,6 +794,19 @@ int timelib_timestamp_is_in_dst(timelib_sll ts, timelib_tzinfo *tz);
 timelib_time_offset *timelib_get_time_zone_info(timelib_sll ts, timelib_tzinfo *tz);
 
 /**
+ * Returns offset information with time zone 'tz' for the time stamp 'ts'.
+ *
+ * The returned information contains: the offset in seconds East of UTC (in
+ * the output parameter 'offset'), whether DST is active (in the output
+ * parameter 'is_dst'), and the transition time that got to this state (in
+ * the output parameter 'transition_time'); if NULL is passed, the value is
+ * not retrieved
+ *
+ * Returns 1 if successful, 0 for failure.
+ */
+int timelib_get_time_zone_offset_info(timelib_sll ts, timelib_tzinfo *tz, int32_t* offset, timelib_sll* transition_time, unsigned int* is_dst);
+
+/**
  * Returns the UTC offset currently applicable for the information stored in 't'.
  *
  * The value returned is the UTC offset in seconds East.


### PR DESCRIPTION
same offset, transition_time and is_dst information as the
timelib_get_time_zone_info API, but without wrapping them in a
heap-allocated structure that also includes a copy of the string
representing the timezone name. Reducing the number of allocations
improves the performance of the code.