### PR TITLE
Accelerate the do_range_limit_days by advancing multiple months in a …

### DIFF
--- a/tests/c/interval.cpp
+++ b/tests/c/interval.cpp
@@ -241,3 +241,16 @@ TEST(timelib_interval, gh8860d)
 	CHECKRES(2022, 10, 30,  3,  0,  0,      0L, 1667095200);
 	LONGS_EQUAL(changed->z, 3600);
 }
+
+TEST(timelib_interval, long_positive_interval)
+{
+	test_add_wall("2000-01-01 00:00:01.500000", "P135000D", 0, 0);
+	CHECKRES(2369,  8,  14,  0,  0,  1, 500000L, 12610684801);
+}
+
+TEST(timelib_interval, long_negative_interval)
+{
+	test_add_wall("2000-01-01 00:00:01.500000", "P135000D", 0, INVERT);
+	CHECKRES(1630,  5,  20,  0,  0,  1, 500000L, -10717315199);
+}
+

--- a/tests/c/interval.cpp
+++ b/tests/c/interval.cpp
@@ -254,3 +254,27 @@ TEST(timelib_interval, long_negative_interval)
 	CHECKRES(1630,  5,  20,  0,  0,  1, 500000L, -10717315199);
 }
 
+TEST(timelib_interval, leap_year_crossing)
+{
+	test_add_wall("2000-02-28 00:00:01.500000", "P1D", 0, 0);
+	CHECKRES(2000,  2,  29,  0,  0,  1, 500000L, 951782401);
+	test_add_wall("2000-02-29 00:00:01.500000", "P1D", 0, INVERT);
+	CHECKRES(2000,  2,  28,  0,  0,  1, 500000L, 951696001);
+	test_add_wall("2000-01-28 00:00:01.500000", "P32D", 0, 0);
+	CHECKRES(2000,  2,  29,  0,  0,  1, 500000L, 951782401);
+	test_add_wall("2000-02-29 00:00:01.500000", "P32D", 0, INVERT);
+	CHECKRES(2000,  1,  28,  0,  0,  1, 500000L, 949017601);
+}
+
+TEST(timelib_interval, non_leap_year_crossing)
+{
+	test_add_wall("2001-02-28 00:00:01.500000", "P1D", 0, 0);
+	CHECKRES(2001,  3,  1,  0,  0,  1, 500000L, 983404801);
+	test_add_wall("2001-03-01 00:00:01.500000", "P1D", 0, INVERT);
+	CHECKRES(2001,  2,  28,  0,  0,  1, 500000L, 983318401);
+	test_add_wall("2001-01-28 00:00:01.500000", "P32D", 0, 0);
+	CHECKRES(2001,  3,  1,  0,  0,  1, 500000L, 983404801);
+	test_add_wall("2001-03-01 00:00:01.500000", "P32D", 0, INVERT);
+	CHECKRES(2001,  1,  28,  0,  0,  1, 500000L, 980640001);
+}
+

--- a/tm2unixtime.c
+++ b/tm2unixtime.c
@@ -104,10 +104,10 @@ static void do_range_limit_days_relative(timelib_sll *base_y, timelib_sll *base_
 static int do_range_limit_days(timelib_sll *y, timelib_sll *m, timelib_sll *d)
 {
 	timelib_sll leapyear;
-	timelib_sll last_month, last_year;
-	timelib_sll days_last_month;
+	timelib_sll previous_month, previous_year;
+	timelib_sll days_in_previous_month;
 	int retval = 0;
-	int* days_per_month_current_year;
+	int *days_per_month_current_year;
 
 	/* can jump an entire leap year period quickly */
 	if (*d >= DAYS_PER_ERA || *d <= -DAYS_PER_ERA) {
@@ -121,17 +121,17 @@ static int do_range_limit_days(timelib_sll *y, timelib_sll *m, timelib_sll *d)
 	days_per_month_current_year = leapyear ? days_in_month_leap : days_in_month;
 
 	while (*d <= 0 && *m > 0) {
-		last_month = (*m) - 1;
-		if (last_month < 1) {
-			last_month += 12;
-			last_year = (*y) - 1;
+		previous_month = (*m) - 1;
+		if (previous_month < 1) {
+			previous_month += 12;
+			previous_year = (*y) - 1;
 		} else {
-			last_year = (*y);
+			previous_year = (*y);
 		}
-		leapyear = timelib_is_leap(last_year);
-		days_last_month = leapyear ? days_in_month_leap[last_month] : days_in_month[last_month];
+		leapyear = timelib_is_leap(previous_year);
+		days_in_previous_month = leapyear ? days_in_month_leap[previous_month] : days_in_month[previous_month];
 
-		*d += days_last_month;
+		*d += days_in_previous_month;
 		(*m)--;
 		retval = 1;
 	}


### PR DESCRIPTION
…single call to the function

Running the body of the new test functions for 1,000,000 times showed that the timelib_add API runs in almost half of the time now (75 seconds instead of 138 seconds)