### PR TITLE
Use the new API timelib_get_time_zone_offset_info, so that fewer

### DIFF
--- a/interval.c
+++ b/interval.c
@@ -90,8 +90,9 @@ static void sort_old_to_new(timelib_time **one, timelib_time **two, timelib_rel_
 static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time *two)
 {
 	timelib_rel_time *rt;
-	timelib_sll dst_corr = 0, dst_h_corr = 0, dst_m_corr = 0;
-	timelib_time_offset *trans = NULL;
+	timelib_sll       dst_corr = 0, dst_h_corr = 0, dst_m_corr = 0;
+	int32_t           trans_offset;
+	timelib_sll       trans_transition_time;
 
 	rt = timelib_rel_time_ctor();
 	rt->invert = 0;
@@ -117,16 +118,16 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 	if (one->dst == 1 && two->dst == 0) {
 		/* First for two "Type 3" times */
 		if (one->zone_type == TIMELIB_ZONETYPE_ID && two->zone_type == TIMELIB_ZONETYPE_ID) {
-			trans = timelib_get_time_zone_info(two->sse, two->tz_info);
-			if (trans) {
-				if (one->sse < trans->transition_time && one->sse >= trans->transition_time + dst_corr) {
+			int success = timelib_get_time_zone_offset_info(two->sse, two->tz_info, &trans_offset, &trans_transition_time, NULL);
+			if (
+				success &&
+				one->sse < trans_transition_time &&
+				one->sse >= trans_transition_time + dst_corr
+			) {
 					timelib_sll flipped = SECS_PER_HOUR + (rt->i * 60) + (rt->s);
 					rt->h = flipped / SECS_PER_HOUR;
 					rt->i = (flipped - rt->h * SECS_PER_HOUR) / 60;
 					rt->s = flipped % 60;
-				}
-				timelib_time_offset_dtor(trans);
-				trans = NULL;
 			}
 		} else if (rt->h == 0 && (rt->i < 0 || rt->s < 0)) {
 			/* Then for all the others */
@@ -145,12 +146,12 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 	if (one->zone_type == TIMELIB_ZONETYPE_ID && two->zone_type == TIMELIB_ZONETYPE_ID && strcmp(one->tz_info->name, two->tz_info->name) == 0) {
 		if (one->dst == 1 && two->dst == 0) { /* Fall Back */
 			if (two->tz_info) {
-				trans = timelib_get_time_zone_info(two->sse, two->tz_info);
+				int success = timelib_get_time_zone_offset_info(two->sse, two->tz_info, &trans_offset, &trans_transition_time, NULL);
 
 				if (
-					trans &&
-					two->sse >= trans->transition_time &&
-					((two->sse - one->sse + dst_corr) % SECS_PER_DAY) > (two->sse - trans->transition_time)
+					success &&
+					two->sse >= trans_transition_time &&
+					((two->sse - one->sse + dst_corr) % SECS_PER_DAY) > (two->sse - trans_transition_time)
 				) {
 					rt->h -= dst_h_corr;
 					rt->i -= dst_m_corr;
@@ -158,13 +159,13 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 			}
 		} else if (one->dst == 0 && two->dst == 1) { /* Spring Forward */
 			if (two->tz_info) {
-				trans = timelib_get_time_zone_info(two->sse, two->tz_info);
+				int success = timelib_get_time_zone_offset_info(two->sse, two->tz_info, &trans_offset, &trans_transition_time, NULL);
 
 				if (
-					trans &&
-					!((one->sse + SECS_PER_DAY > trans->transition_time) && (one->sse + SECS_PER_DAY <= (trans->transition_time + dst_corr))) &&
-					two->sse >= trans->transition_time &&
-					((two->sse - one->sse + dst_corr) % SECS_PER_DAY) > (two->sse - trans->transition_time)
+					success &&
+					!((one->sse + SECS_PER_DAY > trans_transition_time) && (one->sse + SECS_PER_DAY <= (trans_transition_time + dst_corr))) &&
+					two->sse >= trans_transition_time &&
+					((two->sse - one->sse + dst_corr) % SECS_PER_DAY) > (two->sse - trans_transition_time)
 				) {
 					rt->h -= dst_h_corr;
 					rt->i -= dst_m_corr;
@@ -172,12 +173,13 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 			}
 		} else if (two->sse - one->sse >= SECS_PER_DAY) {
 			/* Check whether we're in the period to the next transition time */
-			trans = timelib_get_time_zone_info(two->sse - two->z, two->tz_info);
-			dst_corr = one->z - trans->offset;
+			if (timelib_get_time_zone_offset_info(two->sse - two->z, two->tz_info, &trans_offset, &trans_transition_time, NULL)) {
+				dst_corr = one->z - trans_offset;
 
-			if (two->sse >= trans->transition_time - dst_corr && two->sse < trans->transition_time) {
-				rt->d--;
-				rt->h = 24;
+				if (two->sse >= trans_transition_time - dst_corr && two->sse < trans_transition_time) {
+					rt->d--;
+					rt->h = 24;
+				}
 			}
 		}
 	} else {
@@ -187,10 +189,6 @@ static timelib_rel_time *timelib_diff_with_tzid(timelib_time *one, timelib_time 
 		swap_if_negative(rt);
 
 		timelib_do_rel_normalize(rt->invert ? one : two, rt);
-	}
-
-	if (trans) {
-		timelib_time_offset_dtor(trans);
 	}
 
 	return rt;

--- a/parse_tz.c
+++ b/parse_tz.c
@@ -936,19 +936,16 @@ int timelib_get_time_zone_offset_info(timelib_sll ts, timelib_tzinfo *tz, int32_
 
 timelib_sll timelib_get_current_offset(timelib_time *t)
 {
-	timelib_time_offset *gmt_offset;
-	timelib_sll retval;
-
 	switch (t->zone_type) {
 		case TIMELIB_ZONETYPE_ABBR:
 		case TIMELIB_ZONETYPE_OFFSET:
 			return t->z + (t->dst * 3600);
 
-		case TIMELIB_ZONETYPE_ID:
-			gmt_offset = timelib_get_time_zone_info(t->sse, t->tz_info);
-			retval = gmt_offset->offset;
-			timelib_time_offset_dtor(gmt_offset);
-			return retval;
+		case TIMELIB_ZONETYPE_ID: {
+			int32_t      offset = 0;
+			timelib_get_time_zone_offset_info(t->sse, t->tz_info, &offset, NULL, NULL);
+			return offset;
+		}
 
 		default:
 			return 0;

--- a/tm2unixtime.c
+++ b/tm2unixtime.c
@@ -376,7 +376,11 @@ static void do_adjust_timezone(timelib_time *tz, timelib_tzinfo *tzi)
 
 		default: {
 			/* No timezone in struct, fallback to reference if possible */
-			timelib_time_offset *current, *after;
+			int32_t              current_offset = 0;
+			timelib_sll          current_transition_time = 0;
+			unsigned int         current_is_dst = 0;
+			int32_t              after_offset = 0;
+			timelib_sll          after_transition_time = 0;
 			timelib_sll          adjustment;
 			int                  in_transition;
 			int32_t              actual_offset;
@@ -386,49 +390,47 @@ static void do_adjust_timezone(timelib_time *tz, timelib_tzinfo *tzi)
 				return;
 			}
 
-			current = timelib_get_time_zone_info(tz->sse, tzi);
-			after = timelib_get_time_zone_info(tz->sse - current->offset, tzi);
-			actual_offset = after->offset;
-			actual_transition_time = after->transition_time;
-			if (current->offset == after->offset && tz->have_zone) {
+			timelib_get_time_zone_offset_info(tz->sse, tzi, &current_offset, &current_transition_time, &current_is_dst);
+			timelib_get_time_zone_offset_info(tz->sse - current_offset, tzi, &after_offset, &after_transition_time, NULL);
+			actual_offset = after_offset;
+			actual_transition_time = after_transition_time;
+			if (current_offset == after_offset && tz->have_zone) {
 				/* Make sure we're not missing a DST change because we don't know the actual offset yet */
-				if (current->offset >= 0 && tz->dst && !current->is_dst) {
+				if (current_offset >= 0 && tz->dst && !current_is_dst) {
 						/* Timezone or its DST at or east of UTC, so the local time, interpreted as UTC, leaves DST (as defined in the actual timezone) before the actual local time */
-						timelib_time_offset *earlier;
-						earlier = timelib_get_time_zone_info(tz->sse - current->offset - 7200, tzi);
-						if ((earlier->offset != after->offset) && (tz->sse - earlier->offset < after->transition_time)) {
+						int32_t              earlier_offset;
+						timelib_sll          earlier_transition_time;
+						timelib_get_time_zone_offset_info(tz->sse - current_offset - 7200, tzi, &earlier_offset, &earlier_transition_time, NULL);
+						if ((earlier_offset != after_offset) && (tz->sse - earlier_offset < after_transition_time)) {
 								/* Looking behind a bit clarified the actual offset to use */
-								actual_offset = earlier->offset;
-								actual_transition_time = earlier->transition_time;
+								actual_offset = earlier_offset;
+								actual_transition_time = earlier_transition_time;
 						}
-						timelib_time_offset_dtor(earlier);
-				} else if (current->offset <= 0 && current->is_dst && !tz->dst) {
+				} else if (current_offset <= 0 && current_is_dst && !tz->dst) {
 						/* Timezone west of UTC, so the local time, interpreted as UTC, leaves DST (as defined in the actual timezone) after the actual local time */
-						timelib_time_offset *later;
-						later = timelib_get_time_zone_info(tz->sse - current->offset + 7200, tzi);
-						if ((later->offset != after->offset) && (tz->sse - later->offset >= later->transition_time)) {
+						int32_t              later_offset;
+						timelib_sll          later_transition_time;
+						timelib_get_time_zone_offset_info(tz->sse - current_offset + 7200, tzi, &later_offset, &later_transition_time, NULL);
+						if ((later_offset != after_offset) && (tz->sse - later_offset >= later_transition_time)) {
 								/* Looking ahead a bit clarified the actual offset to use */
-								actual_offset = later->offset;
-								actual_transition_time = later->transition_time;
+								actual_offset = later_offset;
+								actual_transition_time = later_transition_time;
 						}
-						timelib_time_offset_dtor(later);
 				}
 			}
 
 			tz->is_localtime = 1;
 
 			in_transition = (
-				((tz->sse - actual_offset) >= (actual_transition_time + (current->offset - actual_offset))) &&
+				((tz->sse - actual_offset) >= (actual_transition_time + (current_offset - actual_offset))) &&
 				((tz->sse - actual_offset) < actual_transition_time)
 			);
 
-			if ((current->offset != actual_offset) && !in_transition) {
+			if ((current_offset != actual_offset) && !in_transition) {
 				adjustment = -actual_offset;
 			} else {
-				adjustment = -current->offset;
+				adjustment = -current_offset;
 			}
-			timelib_time_offset_dtor(current);
-			timelib_time_offset_dtor(after);
 
 			tz->sse += adjustment;
 			timelib_set_timezone(tz, tzi);

--- a/unixtime2tm.c
+++ b/unixtime2tm.c
@@ -97,11 +97,10 @@ void timelib_update_from_sse(timelib_time *tm)
 		}
 
 		case TIMELIB_ZONETYPE_ID: {
-			timelib_time_offset *gmt_offset;
+			int32_t  offset = 0;
 
-			gmt_offset = timelib_get_time_zone_info(tm->sse, tm->tz_info);
-			timelib_unixtime2gmt(tm, tm->sse + gmt_offset->offset);
-			timelib_time_offset_dtor(gmt_offset);
+			timelib_get_time_zone_offset_info(tm->sse, tm->tz_info, &offset, NULL, NULL);
+			timelib_unixtime2gmt(tm, tm->sse + offset);
 
 			goto cleanup;
 		}


### PR DESCRIPTION
memory allocations are needed during date operations in non-abbreviated
timezones.