### PR TITLE
Avoid error report from ASAN about integer overflow

### DIFF
--- a/tests/c/issues.cpp
+++ b/tests/c/issues.cpp
@@ -1051,3 +1051,24 @@ TEST(issues, php81106)
 	timelib_rel_time_dtor(p);
 	timelib_error_container_dtor(errors);
 }
+
+TEST(issues, sanitizer_issue)
+{
+	int             dummy_error;
+	timelib_tzinfo *tzi;
+	char            current[] = "1949-12-31 22:00:00";
+	tzi = timelib_parse_tzfile((char*) "Asia/Kuwait", timelib_builtin_db(), &dummy_error);
+	timelib_time   *t_cur = timelib_strtotime(current, sizeof(current), NULL, timelib_builtin_db(), timelib_parse_tzfile);
+
+	timelib_update_ts(t_cur, tzi);
+
+	LONGS_EQUAL(1949, t_cur->y);
+	LONGS_EQUAL(12,   t_cur->m);
+	LONGS_EQUAL(31,   t_cur->d);
+	LONGS_EQUAL(22, t_cur->h);
+	LONGS_EQUAL( 0, t_cur->i);
+	LONGS_EQUAL( 0, t_cur->s);
+
+	timelib_time_dtor(t_cur);
+	timelib_tzinfo_dtor(tzi);
+}

--- a/tm2unixtime.c
+++ b/tm2unixtime.c
@@ -423,6 +423,7 @@ static void do_adjust_timezone(timelib_time *tz, timelib_tzinfo *tzi)
 			tz->is_localtime = 1;
 
 			in_transition = (
+				actual_transition_time != INT64_MIN &&
 				((tz->sse - actual_offset) >= (actual_transition_time + (current_offset - actual_offset))) &&
 				((tz->sse - actual_offset) < actual_transition_time)
 			);


### PR DESCRIPTION
While testing with ASAN, I got a report that:

```
runtime error: signed integer overflow: -9223372036854775808 + -716 cannot be represented in type 'long long'
```

It turns out that when do_adjust_timezone is invoked to apply a timezone that doesn't have DST rules, the transition time is set to INT64_MIN; if the new timezone is such that the actual offset is greater than the current offset, the `if` statement is trying to subtract a value from INT64_MIN and this leads to an underflow that makes the number a huge positive number. This is not causing an actual error in the code because the in_transition variable is going to be `false` anyhow, but ASAN complains. Gating the test with a check for DST rule to be actually present avoids the issue