### PR TITLE
timelib.h: remove fallbacks for C99 integer types

### DIFF
--- a/timelib.h
+++ b/timelib.h
@@ -39,22 +39,6 @@
 #include <limits.h>
 #include <inttypes.h>
 
-# ifndef HAVE_INT32_T
-#  if SIZEOF_INT == 4
-typedef int int32_t;
-#  elif SIZEOF_LONG == 4
-typedef long int int32_t;
-#  endif
-# endif
-
-# ifndef HAVE_UINT32_T
-#  if SIZEOF_INT == 4
-typedef unsigned int uint32_t;
-#  elif SIZEOF_LONG == 4
-typedef unsigned long int uint32_t;
-#  endif
-# endif
-
 #ifdef _WIN32
 # if _MSC_VER >= 1600
 # include <stdint.h>


### PR DESCRIPTION
These are mandatory in C99, and no compile-time check is needed.

See https://github.com/php/php-src/pull/10304 for the PHP pull request.