### PR TITLE
Fix memory leak in error path in read_64bit_transitions()

### DIFF
--- a/parse_tz.c
+++ b/parse_tz.c
@@ -211,6 +211,7 @@ static int read_64bit_transitions(const unsigned char **tzf, timelib_tzinfo *tz)
 			buffer[i] = timelib_conv_int64_signed(buffer[i]);
 			/* Sanity check to see whether TS is just increasing */
 			if (i > 0 && !(buffer[i] > buffer[i - 1])) {
+				timelib_free(buffer);
 				return TIMELIB_ERROR_CORRUPT_TRANSITIONS_DONT_INCREASE;
 			}
 		}

--- a/tests/c/parse_tz.cpp
+++ b/tests/c/parse_tz.cpp
@@ -136,3 +136,24 @@ TEST(parse_tz, etc_gmt_2)
 	timelib_tzinfo_dtor(t->tz_info);
 	timelib_time_dtor(t);
 }
+
+TEST(parse_tz, corrupt_transitions_dont_increase)
+{
+	const timelib_tzdb_index_entry index[1] = {
+		{ (char*) "dummy", 0 }
+	};
+	const unsigned char data[] = {
+		'P', 'H', 'P', '2', 0, 'X', 'X', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		'T', 'Z', 'i', 'f', '2',
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,
+		1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	};
+	const timelib_tzdb corrupt_tzdb = { "1", 1, index, data };
+
+	int error;
+	timelib_tzinfo *tzi = timelib_parse_tzfile("dummy", &corrupt_tzdb, &error);
+	CHECK(tzi == NULL);
+	CHECK(error == TIMELIB_ERROR_CORRUPT_TRANSITIONS_DONT_INCREASE);
+}


### PR DESCRIPTION
The buffer is not deallocated along this error path.
Found using static analysis.