### PR TITLE
Allow for NBSP (U+A0) and NNBSP (U+202F) as 'spaces'

### DIFF
--- a/parse_date.re
+++ b/parse_date.re
@@ -661,9 +661,20 @@ static timelib_long timelib_get_month(const char **ptr)
 
 static void timelib_eat_spaces(const char **ptr)
 {
-	while (**ptr == ' ' || **ptr == '\t') {
-		++*ptr;
-	}
+	do {
+		if (**ptr == ' ' || **ptr == '\t') {
+			++*ptr;
+			continue;
+		}
+		if ((*ptr)[0] == '\xe2' && (*ptr)[1] == '\x80' && (*ptr)[2] == '\xaf') { // NNBSP
+			*ptr += 3;
+			continue;
+		}
+		if ((*ptr)[0] == '\xc2' && (*ptr)[1] == '\xa0') { // NBSP
+			*ptr += 2;
+			continue;
+		}
+	} while (false);
 }
 
 static void timelib_eat_until_separator(const char **ptr)
@@ -992,7 +1003,9 @@ std:
 /*!re2c
 any = [\000-\377];
 
-space = [ \t]+;
+nbsp = [\302][\240];
+nnbsp = [\342][\200][\257];
+space = [ \t]+ | nbsp+ | nnbsp+;
 frac = "."[0-9]+;
 
 ago = 'ago';
@@ -1319,6 +1332,7 @@ weekdayof        = (reltextnumber|reltexttext) space (dayfulls|dayfull|dayabbr) 
 				s->time->s = timelib_get_nr(&ptr, 2);
 			}
 		}
+		timelib_eat_spaces(&ptr);
 		s->time->h += timelib_meridian(&ptr, s->time->h);
 		TIMELIB_DEINIT;
 		return TIMELIB_TIME12;
@@ -1746,6 +1760,9 @@ weekdayof        = (reltextnumber|reltexttext) space (dayfulls|dayfull|dayabbr) 
 		s->time->h = timelib_get_nr(&ptr, 2);
 		s->time->i = timelib_get_nr(&ptr, 2);
 		s->time->s = timelib_get_nr(&ptr, 2);
+
+		timelib_eat_spaces(&ptr);
+
 		s->time->z = timelib_parse_zone(&ptr, &s->time->dst, s->time, &tz_not_found, s->tzdb, tz_get_wrapper);
 		if (tz_not_found) {
 			add_error(s, TIMELIB_ERR_TZID_NOT_FOUND, "The timezone could not be found in the database");
@@ -1859,6 +1876,7 @@ weekdayof        = (reltextnumber|reltexttext) space (dayfulls|dayfull|dayabbr) 
 		DEBUG_OUTPUT("tzcorrection | tz");
 		TIMELIB_INIT;
 		TIMELIB_HAVE_TZ();
+		timelib_eat_spaces(&ptr);
 		s->time->z = timelib_parse_zone(&ptr, &s->time->dst, s->time, &tz_not_found, s->tzdb, tz_get_wrapper);
 		if (tz_not_found) {
 			add_error(s, TIMELIB_ERR_TZID_NOT_FOUND, "The timezone could not be found in the database");
@@ -1937,7 +1955,12 @@ weekdayof        = (reltextnumber|reltexttext) space (dayfulls|dayfull|dayabbr) 
 		return TIMELIB_RELATIVE;
 	}
 
-	[ .,\t]
+	[.,]
+	{
+		goto std;
+	}
+
+	space
 	{
 		goto std;
 	}

--- a/tests/c/parse_date.cpp
+++ b/tests/c/parse_date.cpp
@@ -5836,3 +5836,125 @@ TEST(parse_date, ozfuzz_55330)
 	LONGS_EQUAL(errors->error_count, 1);
 	LONGS_EQUAL(errors->error_messages[0].error_code, TIMELIB_ERR_NUMBER_OUT_OF_RANGE);
 }
+
+#define NBSP "\xC2\xA0"
+#define NNBSP "\xE2\x80\xAF"
+
+TEST(parse_date, icu_nnbsp_timetiny12)
+{
+	test_parse("8" NNBSP "pm");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(20, t->h);
+	LONGS_EQUAL(0, t->i);
+	LONGS_EQUAL(0, t->s);
+}
+
+TEST(parse_date, icu_nnbsp_timeshort12_01)
+{
+	test_parse("8:43" NNBSP "pm");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(20, t->h);
+	LONGS_EQUAL(43, t->i);
+	LONGS_EQUAL(0, t->s);
+}
+
+TEST(parse_date, icu_nnbsp_timeshort12_02)
+{
+	test_parse("8:43" NNBSP NNBSP "pm");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(20, t->h);
+	LONGS_EQUAL(43, t->i);
+	LONGS_EQUAL(0, t->s);
+}
+
+TEST(parse_date, icu_nnbsp_timelong12)
+{
+	test_parse("8:43.43" NNBSP "pm");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(20, t->h);
+	LONGS_EQUAL(43, t->i);
+	LONGS_EQUAL(43, t->s);
+}
+
+TEST(parse_date, icu_nnbsp_iso8601normtz_00)
+{
+	test_parse("T17:21:49" "GMT+0230");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(17, t->h);
+	LONGS_EQUAL(21, t->i);
+	LONGS_EQUAL(49, t->s);
+	LONGS_EQUAL(9000, t->z);
+}
+
+TEST(parse_date, icu_nnbsp_iso8601normtz_01)
+{
+	test_parse("T17:21:49" NNBSP "GMT+0230");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(17, t->h);
+	LONGS_EQUAL(21, t->i);
+	LONGS_EQUAL(49, t->s);
+	LONGS_EQUAL(9000, t->z);
+}
+
+TEST(parse_date, icu_nnbsp_iso8601normtz_02)
+{
+	test_parse("T17:21:49" NNBSP NNBSP "GMT+0230");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(17, t->h);
+	LONGS_EQUAL(21, t->i);
+	LONGS_EQUAL(49, t->s);
+	LONGS_EQUAL(9000, t->z);
+}
+
+TEST(parse_date, icu_nnbsp_iso8601normtz_03)
+{
+	test_parse("T17:21:49" NBSP "GMT+0230");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(17, t->h);
+	LONGS_EQUAL(21, t->i);
+	LONGS_EQUAL(49, t->s);
+	LONGS_EQUAL(9000, t->z);
+}
+
+TEST(parse_date, icu_nnbsp_iso8601normtz_04)
+{
+	test_parse("T17:21:49" NNBSP NBSP "GMT+0230");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(17, t->h);
+	LONGS_EQUAL(21, t->i);
+	LONGS_EQUAL(49, t->s);
+	LONGS_EQUAL(9000, t->z);
+}
+
+TEST(parse_date, icu_nnbsp_iso8601normtz_05)
+{
+	test_parse("T17:21:49" NBSP NNBSP "GMT+0230");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(17, t->h);
+	LONGS_EQUAL(21, t->i);
+	LONGS_EQUAL(49, t->s);
+	LONGS_EQUAL(9000, t->z);
+}
+
+TEST(parse_date, icu_nnbsp_iso8601normtz_06)
+{
+	test_parse("T17:21:49" NBSP NBSP "GMT+0230");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(17, t->h);
+	LONGS_EQUAL(21, t->i);
+	LONGS_EQUAL(49, t->s);
+	LONGS_EQUAL(9000, t->z);
+}
+
+TEST(parse_date, icu_nnbsp_clf_01)
+{
+	test_parse("10/Oct/2000:13:55:36" NNBSP "-0230");
+	LONGS_EQUAL(0, errors->error_count);
+	LONGS_EQUAL(2000, t->y);
+	LONGS_EQUAL(10, t->m);
+	LONGS_EQUAL(10, t->d);
+	LONGS_EQUAL(13, t->h);
+	LONGS_EQUAL(55, t->i);
+	LONGS_EQUAL(36, t->s);
+	LONGS_EQUAL(-9000, t->z);
+}


### PR DESCRIPTION
This matches ICU 72.1/CLDR 42 updates, where the time pattern now can include these symbols instead of an ASCII space:

	https://icu.unicode.org/download/72#h.u2dtz3f7ik9a_l