### PR TITLE
Include stdint.h unconditionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ FLAGS=-O0 -ggdb3 \
 	-fno-optimize-sibling-calls \
 	-fstack-protector \
 	-pedantic \
-	-DHAVE_STDINT_H -DHAVE_GETTIMEOFDAY -DHAVE_UNISTD_H -DHAVE_DIRENT_H -I.# -DDEBUG_PARSER
+	-DHAVE_GETTIMEOFDAY -DHAVE_UNISTD_H -DHAVE_DIRENT_H -I.# -DDEBUG_PARSER
 
 CFLAGS_BASE=-Wdeclaration-after-statement ${FLAGS}
 CFLAGS=-fsanitize=address -fsanitize=undefined ${CFLAGS_BASE}

--- a/timelib_private.h
+++ b/timelib_private.h
@@ -45,9 +45,7 @@
 #include <sys/types.h>
 #endif
 
-#if defined(HAVE_STDINT_H)
-# include <stdint.h>
-#endif
+#include <stdint.h>
 
 #if HAVE_UNISTD_H
 # include <unistd.h>


### PR DESCRIPTION
The stdint.h header file is available with the C99 and current systems all have it. It can be included unconditionally.