### PR TITLE
Use strtoll() and atoll() unconditionally

### DIFF
--- a/parse_date.re
+++ b/parse_date.re
@@ -32,16 +32,6 @@
 #include <assert.h>
 #include <limits.h>
 
-#if defined(_MSC_VER)
-# define strtoll(s, f, b) _atoi64(s)
-#elif !defined(HAVE_STRTOLL)
-# if defined(HAVE_ATOLL)
-#  define strtoll(s, f, b) atoll(s)
-# else
-#  define strtoll(s, f, b) strtol(s, f, b)
-# endif
-#endif
-
 #define EOI      257
 #define TIME     258
 #define DATE     259

--- a/parse_iso_intervals.re
+++ b/parse_iso_intervals.re
@@ -27,16 +27,6 @@
 
 #include <ctype.h>
 
-#if defined(_MSC_VER)
-# define strtoll(s, f, b) _atoi64(s)
-#elif !defined(HAVE_STRTOLL)
-# if defined(HAVE_ATOLL)
-#  define strtoll(s, f, b) atoll(s)
-# else
-#  define strtoll(s, f, b) strtol(s, f, b)
-# endif
-#endif
-
 #define EOI      257
 
 #define TIMELIB_PERIOD  260


### PR DESCRIPTION
The strtoll() and atoll() are [C99 standard functions](https://port70.net/~nsz/c/c99/n1256.html#7.20.1.2) and can be used unconditionally on current systems.