### PR TITLE
Address GCC v8.5 `add_with_overflow` pre-processing failure

### DIFF
--- a/parse_date.re
+++ b/parse_date.re
@@ -42,6 +42,14 @@
 # endif
 #endif
 
+#ifndef HAVE_BUILTIN_SADDLL_OVERFLOW
+# if defined(__has_builtin)
+#  if __has_builtin(__builtin_saddll_overflow)
+#    define HAVE_BUILTIN_SADDLL_OVERFLOW
+#  endif
+# endif
+#endif
+
 #define EOI      257
 #define TIME     258
 #define DATE     259
@@ -713,7 +721,7 @@ static const timelib_relunit* timelib_lookup_relunit(const char **ptr)
 
 static void add_with_overflow(Scanner *s, timelib_sll *e, timelib_sll amount, int multiplier)
 {
-#if defined(__has_builtin) && __has_builtin(__builtin_saddll_overflow)
+#if defined(HAVE_BUILTIN_SADDLL_OVERFLOW)
 	if (__builtin_saddll_overflow(*e, amount * multiplier, e)) {
 		add_error(s, TIMELIB_ERR_NUMBER_OUT_OF_RANGE, "Number out of range");
 	}


### PR DESCRIPTION
### Problem Description
The following pre-processing issue appeared when trying compile the library using GCC v8.5:

```sh
[2024/06/21 11:31:06.445] /opt/mongodbtoolchain/v3/bin/gcc -o build/cached/third_party/timelib/dist/parse_date.dyn.o -c -std=c11 -Werror -ffp-contract=off -fasynchronous-unwind-tables -ggdb -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -fno-omit-frame-pointer -fno-strict-aliasing -O2 -march=sandybridge -mtune=generic -mprefer-vector-width=128 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -Wa,--nocompress-debug-sections -fno-builtin-memcmp -DHAVE_GETTIMEOFDAY -DHAVE_STRING_H -DHAVE_DIRENT_H -DHAVE_SYS_TIME_H -DHAVE_UNISTD_H -D_GNU_SOURCE -fPIC -DPCRE_STATIC -DNDEBUG -D_XOPEN_SOURCE=700 -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 -DBOOST_THREAD_VERSION=5 -DBOOST_THREAD_USES_DATETIME -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS -DBOOST_ENABLE_ASSERT_DEBUG_HANDLER -DBOOST_LOG_NO_SHORTHAND_NAMES -DBOOST_LOG_USE_NATIVE_SYSLOG -DBOOST_LOG_WITHOUT_THREAD_ATTR -DABSL_FORCE_ALIGNED_ACCESS -DBOOST_LOG_DYN_LINK -Isrc/third_party/timelib/dist src/third_party/timelib/dist/parse_date.c
...
[2024/06/21 11:31:06.681] parse_date.re: In function 'add_with_overflow':
[2024/06/21 11:31:06.681] parse_date.re:716:44: error: missing binary operator before token "(" 
```

The failure stems the following` __has_builtin` check for `__builtin_saddll_overflow`:

```cpp
static void add_with_overflow(Scanner *s, timelib_sll *e, timelib_sll amount, int multiplier)
{
#if defined(__has_builtin) && __has_builtin(__builtin_saddll_overflow) // <-- fails here
    if (__builtin_saddll_overflow(*e, amount * multiplier, e)) {
        add_error(s, TIMELIB_ERR_NUMBER_OUT_OF_RANGE, "Number out of range");
    }
#else
    *e += (amount * multiplier);
#endif
} 
```

Instead of evaluating to false if `__has_builtin` is missing and stopping there, it will fail with a pre-processing error due to interpreting the missing function as a syntax error. 

Proposed Solution
---
This change breaks down the problematic directive as two separate conditionals, such that if `__has_builtin` is missing, then the second part `__has_builtin(__builtin_saddll_overflow)` won't be evaluated (and lead to the encountered error).