### PR TITLE
Avoid UB in timelib_diff_days()

### DIFF
--- a/interval.c
+++ b/interval.c
@@ -201,7 +201,8 @@ int timelib_diff_days(timelib_time *one, timelib_time *two)
 			days--;
 		}
 	} else {
-		days = fabs(floor(one->sse - two->sse) / 86400);
+		double ddays = fabs(floor(one->sse - two->sse) / 86400);
+		days = ddays <= INT_MAX ? ddays : INT_MAX;
 	}
 
 	return days;


### PR DESCRIPTION
We clamp the calculated days to properly fit in an `int`.

See <https://github.com/php/php-src/issues/17504>.