### PR TITLE
Avoid signed integer overflow in timelib_ts_at_start_of_year()

### DIFF
--- a/parse_posix.c
+++ b/parse_posix.c
@@ -490,6 +490,14 @@ timelib_sll timelib_ts_at_start_of_year(timelib_sll year)
 	timelib_sll epoch_leap_years = count_leap_years(1970);
 	timelib_sll current_leap_years = count_leap_years(year);
 
+	/* FIXME: handle error instead of clamping result */
+	if (year < (TIMELIB_SLL_MIN / SECS_PER_DAY + epoch_leap_years - current_leap_years) / DAYS_PER_YEAR + 1970) {
+		return TIMELIB_SLL_MIN;
+	}
+	if (year > (TIMELIB_SLL_MAX / SECS_PER_DAY + epoch_leap_years - current_leap_years) / DAYS_PER_YEAR + 1970) {
+		return TIMELIB_SLL_MAX;
+	}
+
 	return SECS_PER_DAY * (
 		((year-1970) * DAYS_PER_YEAR)
 		+ current_leap_years

--- a/timelib.h
+++ b/timelib.h
@@ -65,10 +65,14 @@ typedef uint32_t timelib_ulong;
 typedef uint64_t timelib_ull;
 typedef int64_t timelib_sll;
 # define TIMELIB_LL_CONST(n) n ## i64
+# define TIMELIB_SLL_MIN INT64_MIN
+# define TIMELIB_SLL_MAX INT64_MAX
 #else
 typedef unsigned long long timelib_ull;
 typedef signed long long timelib_sll;
 # define TIMELIB_LL_CONST(n) n ## ll
+# define TIMELIB_SLL_MIN LLONG_MIN
+# define TIMELIB_SLL_MAX LLONG_MAX
 #endif
 
 typedef struct _ttinfo ttinfo;


### PR DESCRIPTION
We clamp the calculated timestamp to properly fit into a `timelib_sll` value.

The properly supported range for `year` is [-292,277,022,656, 292,277,026,596] (if `long long` is 64bit).

---

See https://github.com/php/php-src/issues/15150#issuecomment-2642439597; this patch fixes the overflow in `timelib_ts_at_start_of_year()`, although a follow-up overflow would happen in `timelib_get_transitions_for_year()`. Instead of having such checks all over the place, it seems worthwhile to consider to determine a generally supported range of valid years for whole timelib (that might depend on `TIMELIB_SLL_MIN`/`TIMELIB_SSL_MAX` though).