### PR TITLE
Fix PHP GH-17159: "P" format for ::createFromFormat swallows string literals

### DIFF
--- a/parse_date.re
+++ b/parse_date.re
@@ -939,10 +939,12 @@ timelib_long timelib_parse_zone(const char **ptr, int *dst, timelib_time *t, int
 {
 	timelib_tzinfo *res;
 	timelib_long            retval = 0;
+	size_t paren_count = 0;
 
 	*tz_not_found = 0;
 
 	while (**ptr == ' ' || **ptr == '\t' || **ptr == '(') {
+		paren_count += **ptr == '(';
 		++*ptr;
 	}
 	if ((*ptr)[0] == 'G' && (*ptr)[1] == 'M' && (*ptr)[2] == 'T' && ((*ptr)[3] == '+' || (*ptr)[3] == '-')) {
@@ -991,8 +993,9 @@ timelib_long timelib_parse_zone(const char **ptr, int *dst, timelib_time *t, int
 		*tz_not_found = (found == 0);
 		retval = offset;
 	}
-	while (**ptr == ')') {
+	while (paren_count > 0 && **ptr == ')') {
 		++*ptr;
+		paren_count--;
 	}
 	return retval;
 }

--- a/tests/c/parse_tz.cpp
+++ b/tests/c/parse_tz.cpp
@@ -136,3 +136,20 @@ TEST(parse_tz, etc_gmt_2)
 	timelib_tzinfo_dtor(t->tz_info);
 	timelib_time_dtor(t);
 }
+
+TEST(parse_tz, parentheses)
+{
+	timelib_time *t = timelib_time_ctor();
+	const char *tz_name = "((UTC)))";
+	int is_dst;
+	int tz_not_found;
+
+	timelib_parse_zone(&tz_name, &is_dst, t, &tz_not_found, timelib_builtin_db(), test_date_parse_tzfile);
+
+	CHECK(t->tz_info != NULL);
+	STRCMP_EQUAL(t->tz_info->name, "UTC");
+	BYTES_EQUAL(*tz_name, ')');
+
+	timelib_tzinfo_dtor(t->tz_info);
+	timelib_time_dtor(t);
+}


### PR DESCRIPTION
The "P" format specifier consumes '(' at the front and ')' at the back. However, it does not take into account the parenthesis balance. We solve this by only counting the number of opening parentheses and only consuming the same number of closing parentheses.

See: https://github.com/php/php-src/issues/17159