### PR TITLE
Add support for decimal values in relative time expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ C_TESTS=tests/c/timelib_get_current_offset_test.o tests/c/timelib_decimal_hour.o
 	tests/c/parse_date.o tests/c/php-rfc.o tests/c/diff.o tests/c/interval.o \
 	tests/c/timezones_same.o tests/c/diff_days.o \
 	tests/c/timelib_hmsf_to_decimal_hour.o tests/c/dow.o \
-	tests/c/timelib_get_offset_info_test.o tests/c/add.o tests/c/sub.o
+	tests/c/timelib_get_offset_info_test.o tests/c/add.o tests/c/sub.o \
+	tests/c/parse_date_decimal_relative.o
 
 TEST_BINARIES=${MANUAL_TESTS} ${AUTO_TESTS} ctest
 

--- a/parse_date.re
+++ b/parse_date.re
@@ -595,6 +595,45 @@ static timelib_ull timelib_get_signed_nr(Scanner *s, const char **ptr, int max_l
 	return tmp_nr;
 }
 
+static double timelib_get_decimal_nr(const char **ptr, int max_length)
+{
+	const char *begin;
+	char *str;
+	double tmp_nr = 0.0;
+	int len = 0;
+	int sign = 1;
+
+	while ((**ptr == '+') || (**ptr == '-') || (**ptr == ' ') || (**ptr == '\t')) {
+		if (**ptr == '-') {
+			sign = -sign;
+		}
+		++*ptr;
+	}
+
+	while (((**ptr < '0') || (**ptr > '9')) && (**ptr != '.')) {
+		if (**ptr == '\0') {
+			return 0.0;
+		}
+		++*ptr;
+	}
+
+	begin = *ptr;
+	while (((**ptr >= '0') && (**ptr <= '9')) || (**ptr == '.')) {
+		if (len >= max_length) {
+			break;
+		}
+		++*ptr;
+		++len;
+	}
+
+	str = timelib_calloc(1, len + 1);
+	memcpy(str, begin, len);
+	tmp_nr = strtod(str, NULL);
+	timelib_free(str);
+
+	return tmp_nr * sign;
+}
+
 static timelib_sll timelib_lookup_relative_text(const char **ptr, int *behavior)
 {
 	char *word;
@@ -764,6 +803,49 @@ static void timelib_set_relative(const char **ptr, timelib_sll amount, int behav
 			s->time->relative.special.type = relunit->multiplier;
 			s->time->relative.special.amount = amount;
 	}
+}
+
+/*
+ * Set relative time from a decimal value.
+ * Converts decimal units (e.g., 2.5 weeks) to seconds for precision.
+ */
+static void timelib_set_relative_decimal(const char **ptr, double amount, Scanner *s)
+{
+	const timelib_relunit* relunit;
+	double seconds = 0.0;
+
+	if (!(relunit = timelib_lookup_relunit(ptr))) {
+		return;
+	}
+
+	switch (relunit->unit) {
+		case TIMELIB_MICROSEC:
+			s->time->relative.us += (timelib_sll)(amount * relunit->multiplier);
+			return;
+		case TIMELIB_SECOND:
+			seconds = amount * relunit->multiplier;
+			break;
+		case TIMELIB_MINUTE:
+			seconds = amount * relunit->multiplier * 60;
+			break;
+		case TIMELIB_HOUR:
+			seconds = amount * relunit->multiplier * 3600;
+			break;
+		case TIMELIB_DAY:
+			seconds = amount * relunit->multiplier * 86400;
+			break;
+		case TIMELIB_MONTH:
+			seconds = amount * relunit->multiplier * 2629746;
+			break;
+		case TIMELIB_YEAR:
+			seconds = amount * relunit->multiplier * 31556952;
+			break;
+		default:
+			timelib_set_relative(ptr, (timelib_sll)amount, 1, s, TIMELIB_TIME_PART_KEEP);
+			return;
+	}
+
+	s->time->relative.s += (timelib_sll)seconds;
 }
 
 static const timelib_tz_lookup_table* abbr_search(const char *word, timelib_long gmtoffset, int isdst)
@@ -1142,7 +1224,9 @@ reltexttext = 'next'|'last'|'previous'|'this';
 reltextunit = 'ms' | 'µs' | (('msec'|'millisecond'|'µsec'|'microsecond'|'usec'|'sec'|'second'|'min'|'minute'|'hour'|'day'|'fortnight'|'forthnight'|'month'|'year') 's'?) | 'weeks' | daytext;
 
 relnumber = ([+-]*[ \t]*[0-9]{1,13});
+reldecimalnumber = ([+-]*[ \t]*[0-9]+[.][0-9]+);
 relative = relnumber space? (reltextunit | 'week' );
+reldecimal = reldecimalnumber space? (reltextunit | 'week' );
 relativetext = (reltextnumber|reltexttext) space reltextunit;
 relativetextweek = reltexttext space 'week';
 
@@ -1953,6 +2037,22 @@ weekdayof        = (reltextnumber|reltexttext) space (dayfulls|dayfull|dayabbr) 
 		}
 		TIMELIB_DEINIT;
 		return TIMELIB_SHORTDATE_WITH_TIME;
+	}
+
+	reldecimal
+	{
+		double d;
+		DEBUG_OUTPUT("reldecimal");
+		TIMELIB_INIT;
+		TIMELIB_HAVE_RELATIVE();
+
+		while(*ptr) {
+			d = timelib_get_decimal_nr(&ptr, 24);
+			timelib_eat_spaces(&ptr);
+			timelib_set_relative_decimal(&ptr, d, s);
+		}
+		TIMELIB_DEINIT;
+		return TIMELIB_RELATIVE;
 	}
 
 	relative

--- a/tests/c/parse_date_decimal_relative.cpp
+++ b/tests/c/parse_date_decimal_relative.cpp
@@ -1,0 +1,287 @@
+#include "CppUTest/TestHarness.h"
+#include "timelib.h"
+#include "timelib_private.h"
+#include <stdio.h>
+#include <string.h>
+
+TEST_GROUP(parse_date_decimal_relative)
+{
+	timelib_time *t;
+	int           i;
+	timelib_error_container *errors;
+
+	void test_parse(const char *input)
+	{
+		if (t) {
+			if (t->tz_info) {
+				timelib_tzinfo_dtor(t->tz_info);
+			}
+			timelib_time_dtor(t);
+			timelib_error_container_dtor(errors);
+		}
+
+		char *inputCopy = strdup(input);
+		t = timelib_strtotime(
+			inputCopy, strlen(inputCopy),
+			&errors,
+			timelib_builtin_db(),
+			timelib_parse_tzfile
+		);
+
+		free(inputCopy);
+	}
+
+	TEST_TEARDOWN()
+	{
+		if (t->tz_info) {
+			timelib_tzinfo_dtor(t->tz_info);
+		}
+		timelib_time_dtor(t);
+		timelib_error_container_dtor(errors);
+	}
+};
+
+/*
+ * Test cases for GH-21027: strtotime() incorrectly parses decimal relative values
+ * https://github.com/php/php-src/issues/21027
+ */
+
+/* 2.5 weeks = 2.5 * 7 * 86400 = 1512000 seconds */
+TEST(parse_date_decimal_relative, decimal_weeks_01)
+{
+	test_parse("2.5 weeks");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(1512000, t->relative.s);
+}
+
+/* 1.5 weeks = 1.5 * 7 * 86400 = 907200 seconds */
+TEST(parse_date_decimal_relative, decimal_weeks_02)
+{
+	test_parse("1.5 weeks");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(907200, t->relative.s);
+}
+
+/* 0.5 week = 0.5 * 7 * 86400 = 302400 seconds */
+TEST(parse_date_decimal_relative, decimal_weeks_03)
+{
+	test_parse("0.5 week");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(302400, t->relative.s);
+}
+
+/* 2.5 days = 2.5 * 86400 = 216000 seconds */
+TEST(parse_date_decimal_relative, decimal_days_01)
+{
+	test_parse("2.5 days");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(216000, t->relative.s);
+}
+
+/* 1.5 days = 1.5 * 86400 = 129600 seconds */
+TEST(parse_date_decimal_relative, decimal_days_02)
+{
+	test_parse("1.5 days");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(129600, t->relative.s);
+}
+
+/* 2.5 hours = 2.5 * 3600 = 9000 seconds */
+TEST(parse_date_decimal_relative, decimal_hours_01)
+{
+	test_parse("2.5 hours");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(9000, t->relative.s);
+}
+
+/* 1.5 hours = 1.5 * 3600 = 5400 seconds */
+TEST(parse_date_decimal_relative, decimal_hours_02)
+{
+	test_parse("1.5 hours");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(5400, t->relative.s);
+}
+
+/* 2.5 minutes = 2.5 * 60 = 150 seconds */
+TEST(parse_date_decimal_relative, decimal_minutes_01)
+{
+	test_parse("2.5 minutes");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(150, t->relative.s);
+}
+
+/* 1.5 minutes = 1.5 * 60 = 90 seconds */
+TEST(parse_date_decimal_relative, decimal_minutes_02)
+{
+	test_parse("1.5 minutes");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(90, t->relative.s);
+}
+
+/* 1.5 seconds = 1 second (truncated) */
+TEST(parse_date_decimal_relative, decimal_seconds_01)
+{
+	test_parse("1.5 seconds");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(1, t->relative.s);
+}
+
+/* -2.5 weeks = -2.5 * 7 * 86400 = -1512000 seconds */
+TEST(parse_date_decimal_relative, decimal_weeks_negative)
+{
+	test_parse("-2.5 weeks");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(-1512000, t->relative.s);
+}
+
+/* -1.5 days = -1.5 * 86400 = -129600 seconds */
+TEST(parse_date_decimal_relative, decimal_days_negative)
+{
+	test_parse("-1.5 days");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(-129600, t->relative.s);
+}
+
+/* +2.5 hours = 2.5 * 3600 = 9000 seconds */
+TEST(parse_date_decimal_relative, decimal_hours_positive_sign)
+{
+	test_parse("+2.5 hours");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(9000, t->relative.s);
+}
+
+/* 2.5 months = 2.5 * 2629746 = 6574365 seconds */
+TEST(parse_date_decimal_relative, decimal_months_01)
+{
+	test_parse("2.5 months");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(6574365, t->relative.s);
+}
+
+/* 1.5 years = 1.5 * 31556952 = 47335428 seconds */
+TEST(parse_date_decimal_relative, decimal_years_01)
+{
+	test_parse("1.5 years");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(47335428, t->relative.s);
+}
+
+/* 2.37685 weeks = 2.37685 * 7 * 86400 = 1437518.88 -> 1437518 seconds */
+TEST(parse_date_decimal_relative, decimal_weeks_precision)
+{
+	test_parse("2.37685 weeks");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(1437518, t->relative.s);
+}
+
+/* 3.14159 days = 3.14159 * 86400 = 271433.376 -> 271433 seconds */
+TEST(parse_date_decimal_relative, decimal_days_precision)
+{
+	test_parse("3.14159 days");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(271433, t->relative.s);
+}
+
+/* 1.23456 hours = 1.23456 * 3600 = 4444.416 -> 4444 seconds */
+TEST(parse_date_decimal_relative, decimal_hours_precision)
+{
+	test_parse("1.23456 hours");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(4444, t->relative.s);
+}
+
+/* 7.89012 minutes = 7.89012 * 60 = 473.4072 -> 473 seconds */
+TEST(parse_date_decimal_relative, decimal_minutes_precision)
+{
+	test_parse("7.89012 minutes");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(473, t->relative.s);
+}
+
+/* -1.23456 days = -1.23456 * 86400 = -106665.984 -> -106665 seconds */
+TEST(parse_date_decimal_relative, decimal_days_precision_negative)
+{
+	test_parse("-1.23456 days");
+	LONGS_EQUAL(0, t->relative.y);
+	LONGS_EQUAL(0, t->relative.m);
+	LONGS_EQUAL(0, t->relative.d);
+	LONGS_EQUAL(0, t->relative.h);
+	LONGS_EQUAL(0, t->relative.i);
+	LONGS_EQUAL(-106665, t->relative.s);
+}


### PR DESCRIPTION
# Description 

This PR adds support for decimal values in relative time expressions (e.g., `2.5 weeks`, `1.5 days`, `3.14159 hours`).

Fixes: https://github.com/php/php-src/issues/21027

PR on php-src: https://github.com/php/php-src/pull/21034

## Problem

  `strtotime("2.37685 weeks")` returned incorrect result (~414 million seconds instead of ~1.4 million) because:                                                                                           
  - `"2.37"` matched `timeshort24` pattern (hour:minute with dot separator)                                                                                                                                
  - `"685 weeks"` was parsed as separate relative offset                                                                                                                                                   
                                                                                                                                                                                                           
  ## Changes
- Added `reldecimalnumber` regex pattern for decimal numbers
- Added `reldecimal` lexer rule to match decimal relative expressions
- Added `timelib_get_decimal_nr()` helper to parse decimal values
- Added `timelib_set_relative_decimal()` to convert decimal units to seconds
- Added test cases for decimal relative time parsing